### PR TITLE
Fixed typing-indicator in telegram showing even after replying.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -320,7 +320,6 @@ bot.use(limit(
 
 // Get response from AI
 bot.on('message', async (ctx) => {
-    const typing = doTyping(ctx, logger);
 
     const messages: CoreMessage[] = [];
 
@@ -515,8 +514,6 @@ bot.on('message', async (ctx) => {
                 `Empty response from AI`,
             );
 
-            typing.abort();
-
             return;
         }
 
@@ -600,8 +597,6 @@ bot.on('message', async (ctx) => {
 
         await new Promise((resolve) => setTimeout(resolve, msToWait));
     }
-
-    typing.abort();
 });
 
 run(bot);


### PR DESCRIPTION


https://github.com/user-attachments/assets/f99a2357-b737-486a-9541-c75f47f5105e

The main message handler was starting its own typing indicator,
which was already handled by the msg-delay middleware. This commit
removes the duplicate logic in main.ts to prevent the typing
indicator from showing after the bot has responded.