### PR TITLE
Refactor AI prompt helpers and history selection

### DIFF
--- a/lib/ai/language-protocol.ts
+++ b/lib/ai/language-protocol.ts
@@ -1,0 +1,25 @@
+function getLanguageName(localeCode: string): string {
+    const map: Record<string, string> = {
+        ru: 'Russian',
+        uk: 'Ukrainian',
+        en: 'English',
+        pt: 'Portuguese',
+        hi: 'Hindi',
+        id: 'Indonesian',
+    };
+    return map[localeCode] ?? 'the chat language';
+}
+
+export function buildLanguageProtocol(defaultLocale: string): string {
+    const lang = getLanguageName(defaultLocale);
+    return [
+        '### Language Protocol ###',
+        `- Default to ${lang} language in all interactions`,
+        "- Switch to other languages only when: 1) User explicitly writes in other language 2) User directly requests other language 3) User clearly doesn't understand the default language",
+        `- Always return to ${lang} at first opportunity`,
+        '- Maintain authentic speech patterns regardless of language used',
+        '- Answer in short messages like a human would. Do not write long text in one message',
+        '- Each reply must be unique',
+        '- DO NOT REPEAT YOUR OWN MESSAGES OR YOU RISK BEING BANNED IN CHAT',
+    ].join('\n');
+}

--- a/lib/ai/language-protocol_test.ts
+++ b/lib/ai/language-protocol_test.ts
@@ -1,0 +1,12 @@
+import { assertStringIncludes } from '@std/assert';
+import { buildLanguageProtocol } from './language-protocol.ts';
+
+Deno.test('buildLanguageProtocol uses mapped language name', () => {
+    const protocol = buildLanguageProtocol('ru');
+    assertStringIncludes(protocol, 'Default to Russian language');
+});
+
+Deno.test('buildLanguageProtocol falls back to generic language', () => {
+    const protocol = buildLanguageProtocol('zz');
+    assertStringIncludes(protocol, 'Default to the chat language language');
+});

--- a/lib/ai/target-refs.ts
+++ b/lib/ai/target-refs.ts
@@ -1,0 +1,191 @@
+import { ModelMessage } from 'ai';
+import { ChatMessage } from '../memory.ts';
+
+export interface TargetRef {
+    ref: string;
+    messageId: number;
+    userId?: number;
+    username?: string;
+    firstName?: string;
+    preview: string;
+}
+
+function normalizeUsername(value?: string): string | undefined {
+    if (!value) return undefined;
+    return value.startsWith('@') ? value : `@${value}`;
+}
+
+function sanitizeInline(text: string, maxLength = 90): string {
+    const normalized = text.replace(/\s+/g, ' ').trim();
+    if (normalized.length <= maxLength) {
+        return normalized;
+    }
+
+    return `${normalized.slice(0, maxLength)}...`;
+}
+
+export function buildTargetRefs(
+    history: ChatMessage[],
+    maxTargets: number,
+): TargetRef[] {
+    const candidates = history.filter((message) => !message.isMyself)
+        .slice(-maxTargets)
+        .reverse();
+
+    return candidates.map((message, index) => {
+        const text = message.text ?? '';
+        const preview = text.trim().length > 0
+            ? sanitizeInline(text)
+            : '[non-text message]';
+
+        return {
+            ref: `t${index}`,
+            messageId: message.id,
+            userId: message.info.from?.id,
+            username: normalizeUsername(message.info.from?.username),
+            firstName: message.info.from?.first_name,
+            preview,
+        };
+    });
+}
+
+export function buildTargetRefsPrompt(targets: TargetRef[]): string {
+    if (targets.length === 0) {
+        return [
+            '### Reply Target Map ###',
+            '- There are no explicit targets right now.',
+            '- If you reply with text without target_ref, default reply goes to the triggering message.',
+        ].join('\n');
+    }
+
+    const lines = targets.map((target) => {
+        const userPart = target.username ?? target.firstName ?? 'unknown user';
+        const userIdPart = typeof target.userId === 'number'
+            ? `u${target.userId}`
+            : 'u?';
+
+        return `- ${target.ref} -> m${target.messageId}, ${userIdPart}, ${userPart}, text: "${target.preview}"`;
+    });
+
+    return [
+        '### Reply Target Map ###',
+        '- Use target_ref to choose who/what to reply or react to.',
+        '- target_ref must be one of the refs below.',
+        ...lines,
+    ].join('\n');
+}
+
+export function annotateHistoryWithTargetRefs(
+    history: ModelMessage[],
+    targets: TargetRef[],
+): ModelMessage[] {
+    if (targets.length === 0) {
+        return history;
+    }
+
+    const refByMessageId = new Map(
+        targets.map((target) => [target.messageId, target.ref]),
+    );
+
+    const annotateText = (text: string): string => {
+        return text.replace(/^\[m(\d+)\]/, (full, id) => {
+            const ref = refByMessageId.get(Number(id));
+            return ref ? `[${ref}]${full}` : full;
+        });
+    };
+
+    return history.map((entry) => {
+        if (
+            entry.role !== 'system' &&
+            entry.role !== 'user' &&
+            entry.role !== 'assistant'
+        ) {
+            return entry;
+        }
+
+        if (typeof entry.content === 'string') {
+            const annotatedContent = annotateText(entry.content);
+
+            if (annotatedContent === entry.content) {
+                return entry;
+            }
+
+            return {
+                ...entry,
+                content: annotatedContent,
+            };
+        }
+
+        if (entry.role === 'system') {
+            return entry;
+        }
+
+        if (entry.role === 'user') {
+            if (!Array.isArray(entry.content)) {
+                return entry;
+            }
+
+            let hasChanges = false;
+            const annotatedParts = entry.content.map((part) => {
+                if (part.type !== 'text') {
+                    return part;
+                }
+
+                const annotatedText = annotateText(part.text);
+                if (annotatedText === part.text) {
+                    return part;
+                }
+
+                hasChanges = true;
+                return {
+                    ...part,
+                    text: annotatedText,
+                };
+            });
+
+            if (!hasChanges) {
+                return entry;
+            }
+
+            return {
+                ...entry,
+                content: annotatedParts,
+            };
+        }
+
+        if (entry.role === 'assistant') {
+            if (!Array.isArray(entry.content)) {
+                return entry;
+            }
+
+            let hasChanges = false;
+            const annotatedParts = entry.content.map((part) => {
+                if (part.type !== 'text') {
+                    return part;
+                }
+
+                const annotatedText = annotateText(part.text);
+                if (annotatedText === part.text) {
+                    return part;
+                }
+
+                hasChanges = true;
+                return {
+                    ...part,
+                    text: annotatedText,
+                };
+            });
+
+            if (!hasChanges) {
+                return entry;
+            }
+
+            return {
+                ...entry,
+                content: annotatedParts,
+            };
+        }
+
+        return entry;
+    });
+}

--- a/lib/ai/target-refs_test.ts
+++ b/lib/ai/target-refs_test.ts
@@ -1,0 +1,82 @@
+import { assertEquals, assertStringIncludes } from '@std/assert';
+import { ModelMessage } from 'ai';
+import {
+    annotateHistoryWithTargetRefs,
+    buildTargetRefs,
+    buildTargetRefsPrompt,
+} from './target-refs.ts';
+import { ChatMessage } from '../memory.ts';
+import { Message } from 'grammy_types';
+
+function createChatMessage(
+    id: number,
+    text: string,
+    isMyself = false,
+    from?: { id?: number; username?: string; first_name?: string },
+): ChatMessage {
+    return {
+        id,
+        text,
+        isMyself,
+        info: {
+            from,
+        } as unknown as Message,
+    };
+}
+
+Deno.test('buildTargetRefs builds refs from latest external messages', () => {
+    const history: ChatMessage[] = [
+        createChatMessage(10, 'hello one', false, {
+            id: 1,
+            username: 'alice',
+            first_name: 'Alice',
+        }),
+        createChatMessage(11, 'bot msg', true),
+        createChatMessage(12, 'hello two', false, {
+            id: 2,
+            first_name: 'Bob',
+        }),
+    ];
+
+    const refs = buildTargetRefs(history, 5);
+
+    assertEquals(refs.map((r) => r.ref), ['t0', 't1']);
+    assertEquals(refs.map((r) => r.messageId), [12, 10]);
+    assertEquals(refs[0].firstName, 'Bob');
+    assertEquals(refs[1].username, '@alice');
+});
+
+Deno.test('buildTargetRefsPrompt returns fallback when no targets', () => {
+    const prompt = buildTargetRefsPrompt([]);
+    assertStringIncludes(prompt, 'There are no explicit targets right now');
+});
+
+Deno.test('annotateHistoryWithTargetRefs annotates m-id prefixes', () => {
+    const messages: ModelMessage[] = [
+        { role: 'user', content: '[m42][u1:@alice] Alice:\nhi' },
+        {
+            role: 'assistant',
+            content: [{ type: 'text', text: '[m41] ok' }],
+        },
+    ];
+
+    const annotated = annotateHistoryWithTargetRefs(messages, [{
+        ref: 't0',
+        messageId: 42,
+        preview: 'hi',
+    }, {
+        ref: 't1',
+        messageId: 41,
+        preview: 'ok',
+    }]);
+
+    assertEquals(annotated[0], {
+        role: 'user',
+        content: '[t0][m42][u1:@alice] Alice:\nhi',
+    });
+    assertEquals(
+        (annotated[1].content as Array<{ type: string; text: string }>)[0]
+            .text,
+        '[t1][m41] ok',
+    );
+});

--- a/lib/history.ts
+++ b/lib/history.ts
@@ -21,7 +21,12 @@ interface HistoryOptions {
     includeReactions?: boolean;
 }
 
-function resolveReplyThread(
+interface HistoryCandidate {
+    msg: ChatMessage;
+    rootIndex: number;
+}
+
+function collectReplyThread(
     history: ChatMessage[],
     msg: ChatMessage,
     thread: ChatMessage[] = [],
@@ -35,7 +40,7 @@ function resolveReplyThread(
 
     const replyToMsg = history.find((m) => m.id === replyTo.id);
     if (replyToMsg) {
-        return resolveReplyThread(history, replyToMsg, thread);
+        return collectReplyThread(history, replyToMsg, thread);
     } else {
         // For bot relies and stuff not saved in history
         thread.push({
@@ -48,6 +53,51 @@ function resolveReplyThread(
     }
 
     return thread;
+}
+
+export function selectHistoryCandidates(
+    history: ChatMessage[],
+    options: {
+        resolveReplyThread: boolean;
+        maxRootMessages?: number;
+    },
+): HistoryCandidate[] {
+    const selected: HistoryCandidate[] = [];
+    const seen = new Set<number>();
+    let rootMessagesProcessed = 0;
+
+    for (let i = history.length - 1; i >= 0; i--) {
+        if (
+            typeof options.maxRootMessages === 'number' &&
+            rootMessagesProcessed >= options.maxRootMessages
+        ) {
+            break;
+        }
+        rootMessagesProcessed += 1;
+
+        const rootMsg = history[i];
+        if (seen.has(rootMsg.id)) {
+            continue;
+        }
+
+        const thread = options.resolveReplyThread
+            ? collectReplyThread(history, rootMsg)
+            : [rootMsg];
+
+        for (const threadMsg of thread) {
+            if (seen.has(threadMsg.id)) {
+                continue;
+            }
+
+            selected.push({
+                msg: threadMsg,
+                rootIndex: i,
+            });
+            seen.add(threadMsg.id);
+        }
+    }
+
+    return selected;
 }
 
 type PrintType = (name: keyof Message, msg: Message) => string;
@@ -421,86 +471,72 @@ export async function makeHistoryV2(
     let totalBytes = 0;
     let totalAttachments = 0;
     const prompt: ModelMessage[] = [];
-    const addedMessages: number[] = [];
 
-    // Go through history in reverse order
-    // to easily add reply threads and attachments
-    // prioritizing latest messages
-    for (let i = history.length - 1; i >= 0; i--) {
-        const msg = history[i];
+    const candidates = selectHistoryCandidates(history, {
+        resolveReplyThread: resolveReplies,
+    });
+
+    for (const candidate of candidates) {
+        const msg = candidate.msg;
         let attachAttachments = options.attachments ?? true;
 
         // If message is too old, don't attach attachments
-        if (i < history.length - 10 || totalAttachments > 2) {
+        if (candidate.rootIndex < history.length - 10 || totalAttachments > 2) {
             attachAttachments = false;
         }
 
-        // Skip if message is added by reply thread
-        if (addedMessages.includes(msg.id)) {
+        let msgRes;
+
+        try {
+            msgRes = await constructMsg(
+                api,
+                botInfo,
+                msg,
+                {
+                    symbolLimit,
+                    attachments: attachAttachments,
+                    includeReactions: options.includeReactions,
+                },
+            );
+        } catch (error) {
+            logger.error(
+                'Could not construct replied message',
+                {
+                    error,
+                    messageId: msg.id,
+                    isMyself: msg.isMyself,
+                    hasText: Boolean(msg.text),
+                    textLength: msg.text?.length ?? 0,
+                    supportedFields: getSupportedContentFields(msg.info),
+                    unsupportedFields: getUnsupportedContentFields(
+                        msg.info,
+                    ),
+                },
+            );
             continue;
         }
 
-        // Add reply thread
-        const thread = resolveReplyThread(history, msg);
-        for (const msg of thread) {
-            let msgRes;
+        if (Array.isArray(msgRes.content)) {
+            const attachmentsPart = msgRes.content.find((m) =>
+                m.type === 'file' || m.type === 'image'
+            );
 
-            try {
-                msgRes = await constructMsg(
-                    api,
-                    botInfo,
-                    msg,
-                    {
-                        symbolLimit,
-                        attachments: attachAttachments,
-                        includeReactions: options.includeReactions,
-                    },
-                );
-            } catch (error) {
-                logger.error(
-                    'Could not construct replied message',
-                    {
-                        error,
-                        messageId: msg.id,
-                        isMyself: msg.isMyself,
-                        hasText: Boolean(msg.text),
-                        textLength: msg.text?.length ?? 0,
-                        supportedFields: getSupportedContentFields(msg.info),
-                        unsupportedFields: getUnsupportedContentFields(
-                            msg.info,
-                        ),
-                    },
-                );
-                continue;
-            }
-
-            if (Array.isArray(msgRes.content)) {
-                const attachmentsPart = msgRes.content.find((m) =>
-                    m.type === 'file' || m.type === 'image'
-                );
-
-                totalAttachments += attachmentsPart ? 1 : 0;
-            }
-
-            const size = JSON.stringify(msgRes).length;
-
-            if (totalBytes + size >= bytesLimit) {
-                // logger.info(
-                //     `Skipping old messages because prompt is too big ${size} (${
-                //         totalBytes + size
-                //     } > ${bytesLimit})`,
-                // );
-                break;
-            }
-
-            prompt.push(msgRes);
-            addedMessages.push(msg.id);
-            totalBytes += size;
-
-            if (!resolveReplies) {
-                break;
-            }
+            totalAttachments += attachmentsPart ? 1 : 0;
         }
+
+        const size = JSON.stringify(msgRes).length;
+
+        if (totalBytes + size >= bytesLimit) {
+            // logger.info(
+            //     `Skipping old messages because prompt is too big ${size} (${
+            //         totalBytes + size
+            //     } > ${bytesLimit})`,
+            // );
+            break;
+        }
+
+        prompt.push(msgRes);
+        totalBytes += size;
     }
 
     // Reverse messages to make them in chronological order
@@ -531,13 +567,13 @@ export async function makeNotesHistory(
     let totalBytes = 0;
     let textPart = '';
 
-    // Go through history in reverse order
-    for (let i = history.length - 1; i >= 0; i--) {
-        const msg = history[i];
+    const candidates = selectHistoryCandidates(history, {
+        resolveReplyThread: false,
+        maxRootMessages: messagesLimit,
+    });
 
-        if (i < history.length - messagesLimit) {
-            break;
-        }
+    for (const candidate of candidates) {
+        const msg = candidate.msg;
 
         let msgRes;
         try {
@@ -588,9 +624,7 @@ export async function makeNotesHistory(
 
         textPart += content;
 
-        if (i >= history.length - messagesLimit) {
-            textPart += '\n--- ---\n';
-        }
+        textPart += '\n--- ---\n';
 
         totalBytes += size;
     }

--- a/lib/history_test.ts
+++ b/lib/history_test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from '@std/assert';
+import { Message } from 'grammy_types';
+import { ReplyMessage } from './telegram/helpers.ts';
+import { ChatMessage, ReplyTo } from './memory.ts';
+import { selectHistoryCandidates } from './history.ts';
+
+function createReplyTo(id: number): ReplyTo {
+    return {
+        id,
+        text: '',
+        isMyself: false,
+        info: {} as unknown as ReplyMessage,
+    };
+}
+
+function createMessage(id: number, replyToId?: number): ChatMessage {
+    return {
+        id,
+        text: `m${id}`,
+        isMyself: false,
+        replyTo: typeof replyToId === 'number'
+            ? createReplyTo(replyToId)
+            : undefined,
+        info: {} as unknown as Message,
+    };
+}
+
+Deno.test('selectHistoryCandidates includes reply threads and deduplicates', () => {
+    const history: ChatMessage[] = [
+        createMessage(1),
+        createMessage(2, 1),
+        createMessage(3),
+        createMessage(4, 2),
+    ];
+
+    const selected = selectHistoryCandidates(history, {
+        resolveReplyThread: true,
+    });
+
+    assertEquals(selected.map((m) => m.msg.id), [4, 2, 1, 3]);
+});
+
+Deno.test('selectHistoryCandidates respects maxRootMessages', () => {
+    const history: ChatMessage[] = [
+        createMessage(1),
+        createMessage(2),
+        createMessage(3),
+    ];
+
+    const selected = selectHistoryCandidates(history, {
+        resolveReplyThread: false,
+        maxRootMessages: 2,
+    });
+
+    assertEquals(selected.map((m) => m.msg.id), [3, 2]);
+});

--- a/lib/telegram/handlers/ai.ts
+++ b/lib/telegram/handlers/ai.ts
@@ -11,7 +11,7 @@ import {
 import { makeHistoryV2 } from '../../history.ts';
 import { getRandomNepon, prettyDate } from '../../helpers.ts';
 import { replyGeneric, replyWithMarkdownId } from '../helpers.ts';
-import { ChatMessage, ReplyTo } from '../../memory.ts';
+import { ReplyTo } from '../../memory.ts';
 import {
     chatActionsToolInputSchema,
     ChatEntry,
@@ -19,228 +19,16 @@ import {
     isTextEntry,
 } from '../../ai/schema.ts';
 import {
-    canonicalizeReaction,
-    resolveEnabledReactions,
-} from '../reactions.ts';
+    annotateHistoryWithTargetRefs,
+    buildTargetRefs,
+    buildTargetRefsPrompt,
+} from '../../ai/target-refs.ts';
+import { canonicalizeReaction, resolveEnabledReactions } from '../reactions.ts';
 import { isMissingSendTextRightsError } from '../reply-rights.ts';
 import { resolveGenerationPolicy } from '../../ai/generation-policy.ts';
 import { parseModelRef } from '../../ai/model-ref.ts';
 import { buildGenerationTelemetryMetadata } from '../../ai/telemetry-metadata.ts';
-
-interface TargetRef {
-    ref: string;
-    messageId: number;
-    userId?: number;
-    username?: string;
-    firstName?: string;
-    preview: string;
-}
-
-function normalizeUsername(value?: string): string | undefined {
-    if (!value) return undefined;
-    return value.startsWith('@') ? value : `@${value}`;
-}
-
-function sanitizeInline(text: string, maxLength = 90): string {
-    const normalized = text.replace(/\s+/g, ' ').trim();
-    if (normalized.length <= maxLength) {
-        return normalized;
-    }
-
-    return `${normalized.slice(0, maxLength)}...`;
-}
-
-function buildTargetRefs(
-    history: ChatMessage[],
-    maxTargets: number,
-): TargetRef[] {
-    const candidates = history.filter((message) => !message.isMyself)
-        .slice(-maxTargets)
-        .reverse();
-
-    return candidates.map((message, index) => {
-        const text = message.text ?? '';
-        const preview = text.trim().length > 0
-            ? sanitizeInline(text)
-            : '[non-text message]';
-
-        return {
-            ref: `t${index}`,
-            messageId: message.id,
-            userId: message.info.from?.id,
-            username: normalizeUsername(message.info.from?.username),
-            firstName: message.info.from?.first_name,
-            preview,
-        };
-    });
-}
-
-function buildTargetRefsPrompt(targets: TargetRef[]): string {
-    if (targets.length === 0) {
-        return [
-            '### Reply Target Map ###',
-            '- There are no explicit targets right now.',
-            '- If you reply with text without target_ref, default reply goes to the triggering message.',
-        ].join('\n');
-    }
-
-    const lines = targets.map((target) => {
-        const userPart = target.username ?? target.firstName ?? 'unknown user';
-        const userIdPart = typeof target.userId === 'number'
-            ? `u${target.userId}`
-            : 'u?';
-
-        return `- ${target.ref} -> m${target.messageId}, ${userIdPart}, ${userPart}, text: "${target.preview}"`;
-    });
-
-    return [
-        '### Reply Target Map ###',
-        '- Use target_ref to choose who/what to reply or react to.',
-        '- target_ref must be one of the refs below.',
-        ...lines,
-    ].join('\n');
-}
-
-function annotateHistoryWithTargetRefs(
-    history: ModelMessage[],
-    targets: TargetRef[],
-): ModelMessage[] {
-    if (targets.length === 0) {
-        return history;
-    }
-
-    const refByMessageId = new Map(
-        targets.map((target) => [target.messageId, target.ref]),
-    );
-
-    const annotateText = (text: string): string => {
-        return text.replace(/^\[m(\d+)\]/, (full, id) => {
-            const ref = refByMessageId.get(Number(id));
-            return ref ? `[${ref}]${full}` : full;
-        });
-    };
-
-    return history.map((entry) => {
-        if (
-            entry.role !== 'system' &&
-            entry.role !== 'user' &&
-            entry.role !== 'assistant'
-        ) {
-            return entry;
-        }
-
-        if (typeof entry.content === 'string') {
-            const annotatedContent = annotateText(entry.content);
-
-            if (annotatedContent === entry.content) {
-                return entry;
-            }
-
-            return {
-                ...entry,
-                content: annotatedContent,
-            };
-        }
-
-        if (entry.role === 'system') {
-            return entry;
-        }
-
-        if (entry.role === 'user') {
-            if (!Array.isArray(entry.content)) {
-                return entry;
-            }
-
-            let hasChanges = false;
-            const annotatedParts = entry.content.map((part) => {
-                if (part.type !== 'text') {
-                    return part;
-                }
-
-                const annotatedText = annotateText(part.text);
-                if (annotatedText === part.text) {
-                    return part;
-                }
-
-                hasChanges = true;
-                return {
-                    ...part,
-                    text: annotatedText,
-                };
-            });
-
-            if (!hasChanges) {
-                return entry;
-            }
-
-            return {
-                ...entry,
-                content: annotatedParts,
-            };
-        }
-
-        if (entry.role === 'assistant') {
-            if (!Array.isArray(entry.content)) {
-                return entry;
-            }
-
-            let hasChanges = false;
-            const annotatedParts = entry.content.map((part) => {
-                if (part.type !== 'text') {
-                    return part;
-                }
-
-                const annotatedText = annotateText(part.text);
-                if (annotatedText === part.text) {
-                    return part;
-                }
-
-                hasChanges = true;
-                return {
-                    ...part,
-                    text: annotatedText,
-                };
-            });
-
-            if (!hasChanges) {
-                return entry;
-            }
-
-            return {
-                ...entry,
-                content: annotatedParts,
-            };
-        }
-
-        return entry;
-    });
-}
-
-function getLanguageName(localeCode: string): string {
-    const map: Record<string, string> = {
-        ru: 'Russian',
-        uk: 'Ukrainian',
-        en: 'English',
-        pt: 'Portuguese',
-        hi: 'Hindi',
-        id: 'Indonesian',
-    };
-    return map[localeCode] ?? 'the chat language';
-}
-
-function buildLanguageProtocol(defaultLocale: string): string {
-    const lang = getLanguageName(defaultLocale);
-    return [
-        '### Language Protocol ###',
-        `- Default to ${lang} language in all interactions`,
-        "- Switch to other languages only when: 1) User explicitly writes in other language 2) User directly requests other language 3) User clearly doesn't understand the default language",
-        `- Always return to ${lang} at first opportunity`,
-        '- Maintain authentic speech patterns regardless of language used',
-        '- Answer in short messages like a human would. Do not write long text in one message',
-        '- Each reply must be unique',
-        '- DO NOT REPEAT YOUR OWN MESSAGES OR YOU RISK BEING BANNED IN CHAT',
-    ].join('\n');
-}
+import { buildLanguageProtocol } from '../../ai/language-protocol.ts';
 
 export default function registerAI(bot: Bot<SlushaContext>) {
     const sendChatActionsTool = tool({
@@ -306,7 +94,8 @@ export default function registerAI(bot: Bot<SlushaContext>) {
                     entries: [
                         {
                             type: 'reply',
-                            text: 'just a text message with no reactions which is preferred for most cases',
+                            text:
+                                'just a text message with no reactions which is preferred for most cases',
                             target_ref: 't0',
                         },
                     ],
@@ -422,7 +211,9 @@ export default function registerAI(bot: Bot<SlushaContext>) {
                     '\n\n### Reactions ###\n- Reactions are disabled for this chat. Do not output react actions.';
             } else {
                 prompt +=
-                    `\n\n### Reactions ###\n- Allowed reactions for this chat: ${enabledReactions.join(', ')}`;
+                    `\n\n### Reactions ###\n- Allowed reactions for this chat: ${
+                        enabledReactions.join(', ')
+                    }`;
             }
 
             prompt += `\n\n${buildTargetRefsPrompt(targetRefs)}`;
@@ -462,7 +253,10 @@ export default function registerAI(bot: Bot<SlushaContext>) {
             return;
         }
 
-        const annotatedHistory = annotateHistoryWithTargetRefs(history, targetRefs);
+        const annotatedHistory = annotateHistoryWithTargetRefs(
+            history,
+            targetRefs,
+        );
         messages.push(...annotatedHistory);
 
         let finalPrompt = useJsonResponses
@@ -592,7 +386,9 @@ export default function registerAI(bot: Bot<SlushaContext>) {
                             modelRef,
                             chatId: ctx.chat.id,
                             finishReason: result.finishReason,
-                            toolCalls: result.toolCalls.map((call) => call.toolName),
+                            toolCalls: result.toolCalls.map((call) =>
+                                call.toolName
+                            ),
                             usage: result.totalUsage,
                         },
                     );
@@ -655,16 +451,21 @@ export default function registerAI(bot: Bot<SlushaContext>) {
             `for "${name}" ${username}. `,
         );
 
-        function resolveTargetMessageId(targetRef?: string): number | undefined {
+        function resolveTargetMessageId(
+            targetRef?: string,
+        ): number | undefined {
             if (targetRef) {
                 const fromMap = targetRefMap.get(targetRef);
                 if (fromMap) {
                     return fromMap;
                 }
 
-                logger.debug('Unknown target_ref, fallback to trigger message', {
-                    targetRef,
-                });
+                logger.debug(
+                    'Unknown target_ref, fallback to trigger message',
+                    {
+                        targetRef,
+                    },
+                );
             }
 
             return ctx.msg.message_id;


### PR DESCRIPTION
## Summary
- extract target ref mapping/annotation and language protocol into standalone pure modules used by Telegram AI handler
- refactor history building with a shared `selectHistoryCandidates` pipeline used by both chat history and notes history generation
- add focused tests for new helper modules and history candidate selection behavior

## Verification
- deno check --allow-import main.ts
- deno lint
- AI_TOKEN=\"test\" deno test -A