### PR TITLE
Add configurable per-user and per-chat request windows

### DIFF
--- a/drizzle/0006_request_window_usage.sql
+++ b/drizzle/0006_request_window_usage.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `request_window_events` (
+    `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    `chat_id` integer NOT NULL,
+    `user_id` integer,
+    `created_at` integer NOT NULL
+);
+
+CREATE INDEX `request_window_events_chat_time_idx`
+ON `request_window_events` (`chat_id`, `created_at`);
+
+CREATE INDEX `request_window_events_user_time_idx`
+ON `request_window_events` (`user_id`, `created_at`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
             "when": 1772895600000,
             "tag": "0005_history_v3_threads",
             "breakpoints": true
+        },
+        {
+            "idx": 6,
+            "version": "7",
+            "when": 1772978400000,
+            "tag": "0006_request_window_usage",
+            "breakpoints": true
         }
     ]
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -42,6 +42,22 @@ const generationTaskSchema = z.object({
     openrouterReasoning: openrouterReasoningSchema.optional(),
     maxOutputTokens: z.number().int().min(1).max(65536).optional(),
 });
+const requestWindowLimitSchema = z.object({
+    maxRequests: boundedPositiveInt(1, 100000),
+    windowMinutes: boundedPositiveInt(1, 7 * 24 * 60),
+});
+const requestWindowLimitOverrideSchema = z.object({
+    maxRequests: boundedPositiveInt(1, 100000).optional(),
+    windowMinutes: boundedPositiveInt(1, 7 * 24 * 60).optional(),
+});
+const requestWindowTierSchema = z.object({
+    perUser: requestWindowLimitSchema,
+    perChat: requestWindowLimitSchema,
+});
+const requestWindowPerChatOverrideSchema = z.object({
+    free: requestWindowLimitOverrideSchema.optional(),
+    trusted: requestWindowLimitOverrideSchema.optional(),
+});
 
 const defaultGoogleSafetySettings: Array<
     { category: string; threshold: string }
@@ -171,6 +187,18 @@ export const configSchema = z.object({
     chatLastUseNotes: boundedPositiveInt(1, 100).default(3),
     chatLastUseMemory: boundedPositiveInt(1, 100).default(2),
     responseDelay: z.number().min(0).max(120).default(1),
+    requestWindow: z.object({
+        free: requestWindowTierSchema,
+        trusted: requestWindowTierSchema,
+        downgradeModel: z.string().min(1).max(200),
+        disableLongContext: z.boolean().default(true),
+        downgradeMessagesToPass: boundedPositiveInt(1, 100).default(4),
+        downgradeBytesLimit: boundedPositiveInt(1024, 100 * 1024 * 1024)
+            .default(1024 * 1024),
+        disableNotes: z.boolean().default(true),
+        disableAttachments: z.boolean().default(true),
+        disableMemory: z.boolean().default(true),
+    }),
 });
 
 const chatOverrideAiSchema = z.object({
@@ -212,6 +240,7 @@ export const chatConfigOverrideSchema = z.object({
     responseDelay: configSchema.shape.responseDelay.optional(),
     disableRepliesDueToRights: z.boolean().optional(),
     disabledReplyRightsLastProbeAt: z.number().int().min(0).optional(),
+    requestWindowPerChat: requestWindowPerChatOverrideSchema.optional(),
 });
 
 export const safetySettings: Array<{ category: string; threshold: string }> = [
@@ -450,10 +479,10 @@ export function mergeWithChatOverride(
     };
 
     const entries = Object.entries(override).filter(([k]) =>
-        k !== 'ai'
+        k !== 'ai' && k !== 'requestWindowPerChat'
     ) as Array<[
-        keyof Omit<ChatConfigOverride, 'ai'>,
-        ChatConfigOverride[keyof Omit<ChatConfigOverride, 'ai'>],
+        keyof Omit<ChatConfigOverride, 'ai' | 'requestWindowPerChat'>,
+        ChatConfigOverride[keyof Omit<ChatConfigOverride, 'ai' | 'requestWindowPerChat'>],
     ]>;
 
     for (const [key, value] of entries) {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -140,3 +140,10 @@ export const chatCharacters = sqliteTable('chat_characters', {
     payload: text('payload').notNull(),
     names: text('names').notNull(),
 });
+
+export const requestWindowEvents = sqliteTable('request_window_events', {
+    id: integer('id', { mode: 'number' }).primaryKey({ autoIncrement: true }),
+    chatId: integer('chat_id', { mode: 'number' }).notNull(),
+    userId: integer('user_id', { mode: 'number' }),
+    createdAt: integer('created_at', { mode: 'number' }).notNull(),
+});

--- a/lib/default-config.ts
+++ b/lib/default-config.ts
@@ -222,6 +222,35 @@ const defaultConfig = {
     chatLastUseNotes: 2,
     chatLastUseMemory: 2,
     responseDelay: 1,
+    requestWindow: {
+        free: {
+            perUser: {
+                maxRequests: 30,
+                windowMinutes: 180,
+            },
+            perChat: {
+                maxRequests: 120,
+                windowMinutes: 180,
+            },
+        },
+        trusted: {
+            perUser: {
+                maxRequests: 300,
+                windowMinutes: 180,
+            },
+            perChat: {
+                maxRequests: 1200,
+                windowMinutes: 180,
+            },
+        },
+        downgradeModel: 'gemini-3.1-flash-lite-preview',
+        disableLongContext: true,
+        downgradeMessagesToPass: 4,
+        downgradeBytesLimit: 1024 * 1024,
+        disableNotes: true,
+        disableAttachments: true,
+        disableMemory: true,
+    },
 };
 
 export default defaultConfig;

--- a/lib/default-config.ts
+++ b/lib/default-config.ts
@@ -244,12 +244,12 @@ const defaultConfig = {
             },
         },
         downgradeModel: 'gemini-3.1-flash-lite-preview',
-        disableLongContext: true,
+        disableLongContext: false,
         downgradeMessagesToPass: 4,
-        downgradeBytesLimit: 1024 * 1024,
-        disableNotes: true,
-        disableAttachments: true,
-        disableMemory: true,
+        downgradeBytesLimit: 20 * 1024 * 1024,
+        disableNotes: false,
+        disableAttachments: false,
+        disableMemory: false,
     },
 };
 

--- a/lib/telegram/bot/notes.ts
+++ b/lib/telegram/bot/notes.ts
@@ -11,6 +11,7 @@ import {
 } from '../../ai/chat-context.ts';
 import { resolveGenerationPolicy } from '../../ai/generation-policy.ts';
 import { buildGenerationTelemetryMetadata } from '../../ai/telemetry-metadata.ts';
+import { getUsageSnapshot } from '../usage-window.ts';
 
 export default function notes(config: Config, botId: number) {
     const bot = new Composer<SlushaContext>();
@@ -19,6 +20,19 @@ export default function notes(config: Config, botId: number) {
     bot.on('message', (ctx, next) => {
         async function handleNotes() {
             const effectiveConfig = await ctx.m.getEffectiveConfig();
+            const chatOverride = await ctx.m.getChatConfigOverride();
+            const usageSnapshot = await getUsageSnapshot(ctx.memory.db, {
+                config: effectiveConfig,
+                chatId: ctx.chat.id,
+                userId: ctx.from?.id,
+                chatOverride,
+            });
+            if (
+                usageSnapshot.downgraded &&
+                effectiveConfig.requestWindow.disableNotes
+            ) {
+                return;
+            }
             const frequency = effectiveConfig.ai.notesFrequency;
             const chat = await ctx.m.getChat();
             const history = await ctx.m.getRecentHistory(frequency);
@@ -173,6 +187,19 @@ export default function notes(config: Config, botId: number) {
     bot.on('message', (ctx, next) => {
         async function handleMemory() {
             const effectiveConfig = await ctx.m.getEffectiveConfig();
+            const chatOverride = await ctx.m.getChatConfigOverride();
+            const usageSnapshot = await getUsageSnapshot(ctx.memory.db, {
+                config: effectiveConfig,
+                chatId: ctx.chat.id,
+                userId: ctx.from?.id,
+                chatOverride,
+            });
+            if (
+                usageSnapshot.downgraded &&
+                effectiveConfig.requestWindow.disableMemory
+            ) {
+                return;
+            }
             const frequency = effectiveConfig.ai.memoryFrequency;
             const chat = await ctx.m.getChat();
             const history = await ctx.m.getRecentHistory(frequency);

--- a/lib/telegram/commands/usage.ts
+++ b/lib/telegram/commands/usage.ts
@@ -1,0 +1,57 @@
+import { Composer } from 'grammy';
+import { SlushaContext } from '../setup-bot.ts';
+import {
+    getUsageSnapshot,
+    renderProgressBar,
+} from '../usage-window.ts';
+
+function formatWindowLine(
+    label: string,
+    used: number,
+    maxRequests: number,
+    windowMinutes: number,
+): string {
+    const bar = renderProgressBar(used, maxRequests, 16);
+    return `${label}: ${bar} ${used}/${maxRequests} (${windowMinutes}m)`;
+}
+
+export function registerUsage(composer: Composer<SlushaContext>) {
+    composer.command('usage', async (ctx) => {
+        const effectiveConfig = await ctx.m.getEffectiveConfig();
+        const chatOverride = await ctx.m.getChatConfigOverride();
+        const snapshot = await getUsageSnapshot(ctx.memory.db, {
+            config: effectiveConfig,
+            chatId: ctx.chat.id,
+            userId: ctx.from?.id,
+            chatOverride,
+        });
+
+        const lines = [
+            ctx.t('usage-title', { tier: snapshot.tier }),
+            formatWindowLine(
+                ctx.t('usage-user-window'),
+                snapshot.user.used,
+                snapshot.user.maxRequests,
+                snapshot.user.windowMinutes,
+            ),
+            formatWindowLine(
+                ctx.t('usage-chat-window'),
+                snapshot.chat.used,
+                snapshot.chat.maxRequests,
+                snapshot.chat.windowMinutes,
+            ),
+        ];
+
+        if (snapshot.downgraded) {
+            lines.push(
+                ctx.t('usage-downgraded', {
+                    model: effectiveConfig.requestWindow.downgradeModel,
+                }),
+            );
+        } else {
+            lines.push(ctx.t('usage-normal'));
+        }
+
+        return ctx.reply(lines.join('\n'));
+    });
+}

--- a/lib/telegram/handlers/ai.ts
+++ b/lib/telegram/handlers/ai.ts
@@ -42,6 +42,11 @@ import { resolveGenerationPolicy } from '../../ai/generation-policy.ts';
 import { parseModelRef } from '../../ai/model-ref.ts';
 import { buildGenerationTelemetryMetadata } from '../../ai/telemetry-metadata.ts';
 import { buildLanguageProtocol } from '../../ai/language-protocol.ts';
+import {
+    cleanupUsageEvents,
+    getUsageSnapshot,
+    recordUsageEvent,
+} from '../usage-window.ts';
 
 const DEFAULT_CHAT_ACTIONS_TOOL_DESCRIPTION =
     'Submit Telegram actions once per turn. Return entries where each item is either {"type":"reply","text":"...","target_ref":"tN"} or {"type":"react","react":"❤","target_ref":"tN"}. Use target_ref values from Reply Target Map. If target_ref is omitted, action applies to the triggering message.';
@@ -544,6 +549,24 @@ export default function registerAI(bot: Bot<SlushaContext>) {
     bot.on('message', async (ctx) => {
         const chatState = await ctx.m.getChat();
         const effectiveConfig = await ctx.m.getEffectiveConfig();
+        const chatOverride = await ctx.m.getChatConfigOverride();
+        await recordUsageEvent(ctx.memory.db, {
+            chatId: ctx.chat.id,
+            userId: ctx.from?.id,
+        });
+        await cleanupUsageEvents(ctx.memory.db, effectiveConfig);
+        const usageSnapshot = await getUsageSnapshot(ctx.memory.db, {
+            config: effectiveConfig,
+            chatId: ctx.chat.id,
+            userId: ctx.from?.id,
+            chatOverride,
+        });
+        const usageConfig = effectiveConfig.requestWindow;
+        const isDowngraded = usageSnapshot.downgraded;
+        const includeNotes = !isDowngraded || !usageConfig.disableNotes;
+        const includeMemory = !isDowngraded || !usageConfig.disableMemory;
+        const includeAttachments = !isDowngraded ||
+            !usageConfig.disableAttachments;
         const sendChatActionsTool = createSendChatActionsTool(
             resolveCustomPrompt(
                 effectiveConfig.ai.chatActionsToolDescription,
@@ -563,8 +586,14 @@ export default function registerAI(bot: Bot<SlushaContext>) {
             effectiveConfig.blacklistedReactions,
         );
 
-        const messagesToPass = chatState.messagesToPass ??
+        const baseMessagesToPass = chatState.messagesToPass ??
             effectiveConfig.ai.messagesToPass;
+        const messagesToPass = isDowngraded && usageConfig.disableLongContext
+            ? Math.min(baseMessagesToPass, usageConfig.downgradeMessagesToPass)
+            : baseMessagesToPass;
+        const bytesLimit = isDowngraded && usageConfig.disableLongContext
+            ? Math.min(effectiveConfig.ai.bytesLimit, usageConfig.downgradeBytesLimit)
+            : effectiveConfig.ai.bytesLimit;
         const maxTargetCount = Math.min(
             Math.max(messagesToPass * 2, 12),
             40,
@@ -588,7 +617,9 @@ export default function registerAI(bot: Bot<SlushaContext>) {
             await ctx.i18n.getLocale();
         const character = chatState.character;
 
-        const modelRef = chatState.chatModel ?? effectiveConfig.ai.model;
+        const modelRef = isDowngraded
+            ? usageConfig.downgradeModel
+            : (chatState.chatModel ?? effectiveConfig.ai.model);
         const parsedModel = parseModelRef(modelRef);
 
         const time = new Date().getTime();
@@ -600,6 +631,9 @@ export default function registerAI(bot: Bot<SlushaContext>) {
         }
         if (ctx.info.isRandom) {
             tags.push('random');
+        }
+        if (isDowngraded) {
+            tags.push('downgraded');
         }
         const chatName = ctx.chat.first_name ?? ctx.chat.title;
 
@@ -660,8 +694,8 @@ export default function registerAI(bot: Bot<SlushaContext>) {
                 activeMembers,
                 notes: chatState.notes,
                 memory: chatState.memory,
-                includeNotes: plan.includeBotNotes,
-                includeMemory: plan.includeBotNotes,
+                includeNotes: plan.includeBotNotes && includeNotes,
+                includeMemory: plan.includeBotNotes && includeMemory,
             });
 
             prompt += `\n\n### Chat Info ###\n${chatInfoMsg}`;
@@ -692,12 +726,13 @@ export default function registerAI(bot: Bot<SlushaContext>) {
                 savedHistory,
                 {
                     messagesLimit: plan.historyLimit,
-                    bytesLimit: effectiveConfig.ai.bytesLimit,
+                    bytesLimit,
                     symbolLimit: effectiveConfig.ai.messageMaxLength,
                     includeReactions: true,
                     activeMessageId: ctx.msg.message_id,
                     attachments:
                         effectiveConfig.ai.includeAttachmentsInHistory &&
+                        includeAttachments &&
                         parsedModel.provider === 'google',
                 },
             );

--- a/lib/telegram/register-commands.ts
+++ b/lib/telegram/register-commands.ts
@@ -9,6 +9,7 @@ import { registerRandom } from './commands/random.ts';
 import { registerSummary } from './commands/summary.ts';
 import registerHateMode from './commands/hatemode.ts';
 import { registerConfig } from './commands/config.ts';
+import { registerUsage } from './commands/usage.ts';
 
 export function registerEarlyCommands(bot: Composer<SlushaContext>) {
     bot.use(start);
@@ -25,4 +26,5 @@ export function registerLateCommands(
     registerSummary(bot);
     registerHateMode(bot);
     registerConfig(bot);
+    registerUsage(bot);
 }

--- a/lib/telegram/setup-bot.ts
+++ b/lib/telegram/setup-bot.ts
@@ -195,6 +195,7 @@ const commands = [
     '/summary',
     '/language',
     '/config',
+    '/usage',
 ];
 
 const startDate = new Date();

--- a/lib/telegram/usage-window.ts
+++ b/lib/telegram/usage-window.ts
@@ -1,0 +1,171 @@
+import { and, eq, gte, lt, sql } from 'drizzle-orm';
+import { ChatConfigOverride, UserConfig } from '../config.ts';
+import { DbClient } from '../db/client.ts';
+import { requestWindowEvents } from '../db/schema.ts';
+
+export type UsageTier = 'free' | 'trusted';
+
+type UsageLimit = {
+    maxRequests: number;
+    windowMinutes: number;
+};
+
+export type UsageCounterSnapshot = UsageLimit & {
+    used: number;
+    remaining: number;
+    ratio: number;
+};
+
+export type UsageSnapshot = {
+    tier: UsageTier;
+    downgraded: boolean;
+    downgradeReason: 'none' | 'user' | 'chat' | 'both';
+    user: UsageCounterSnapshot;
+    chat: UsageCounterSnapshot;
+};
+
+function clampRatio(used: number, maxRequests: number): number {
+    if (maxRequests <= 0) return 0;
+    return Math.max(0, Math.min(1, used / maxRequests));
+}
+
+function withCount(limit: UsageLimit, used: number): UsageCounterSnapshot {
+    return {
+        ...limit,
+        used,
+        remaining: Math.max(0, limit.maxRequests - used),
+        ratio: clampRatio(used, limit.maxRequests),
+    };
+}
+
+function mergeLimit(
+    base: UsageLimit,
+    override?: Partial<UsageLimit>,
+): UsageLimit {
+    return {
+        maxRequests: override?.maxRequests ?? base.maxRequests,
+        windowMinutes: override?.windowMinutes ?? base.windowMinutes,
+    };
+}
+
+export function resolveUsageTier(config: UserConfig, userId?: number): UsageTier {
+    if (userId && config.trustedIds.includes(userId)) {
+        return 'trusted';
+    }
+    return 'free';
+}
+
+export function resolvePerChatLimit(
+    config: UserConfig,
+    tier: UsageTier,
+    override?: ChatConfigOverride,
+): UsageLimit {
+    const base = config.requestWindow[tier].perChat;
+    const chatOverride = override?.requestWindowPerChat?.[tier];
+    return mergeLimit(base, chatOverride);
+}
+
+function resolvePerUserLimit(config: UserConfig, tier: UsageTier): UsageLimit {
+    return config.requestWindow[tier].perUser;
+}
+
+export async function cleanupUsageEvents(
+    db: DbClient,
+    config: UserConfig,
+    now = Date.now(),
+) {
+    const limits = [
+        config.requestWindow.free.perUser.windowMinutes,
+        config.requestWindow.free.perChat.windowMinutes,
+        config.requestWindow.trusted.perUser.windowMinutes,
+        config.requestWindow.trusted.perChat.windowMinutes,
+    ];
+    const maxWindowMinutes = Math.max(...limits);
+    const cutoff = now - maxWindowMinutes * 60 * 1000;
+    await db.delete(requestWindowEvents).where(
+        lt(requestWindowEvents.createdAt, cutoff),
+    );
+}
+
+export async function recordUsageEvent(
+    db: DbClient,
+    input: { chatId: number; userId?: number; now?: number },
+) {
+    await db.insert(requestWindowEvents).values({
+        chatId: input.chatId,
+        userId: input.userId,
+        createdAt: input.now ?? Date.now(),
+    });
+}
+
+export async function getUsageSnapshot(
+    db: DbClient,
+    input: {
+        config: UserConfig;
+        chatId: number;
+        userId?: number;
+        chatOverride?: ChatConfigOverride;
+        now?: number;
+    },
+): Promise<UsageSnapshot> {
+    const now = input.now ?? Date.now();
+    const tier = resolveUsageTier(input.config, input.userId);
+    const userLimit = resolvePerUserLimit(input.config, tier);
+    const chatLimit = resolvePerChatLimit(input.config, tier, input.chatOverride);
+
+    const userWindowStart = now - userLimit.windowMinutes * 60 * 1000;
+    const chatWindowStart = now - chatLimit.windowMinutes * 60 * 1000;
+
+    const [userRows, chatRows] = await Promise.all([
+        input.userId
+            ? db.select({ total: sql<number>`count(*)` })
+                .from(requestWindowEvents)
+                .where(and(
+                    eq(requestWindowEvents.userId, input.userId),
+                    gte(requestWindowEvents.createdAt, userWindowStart),
+                ))
+            : Promise.resolve([{ total: 0 }]),
+        db.select({ total: sql<number>`count(*)` })
+            .from(requestWindowEvents)
+            .where(and(
+                eq(requestWindowEvents.chatId, input.chatId),
+                gte(requestWindowEvents.createdAt, chatWindowStart),
+            )),
+    ]);
+
+    const userUsed = userRows[0]?.total ?? 0;
+    const chatUsed = chatRows[0]?.total ?? 0;
+
+    const user = withCount(userLimit, userUsed);
+    const chat = withCount(chatLimit, chatUsed);
+
+    const userExceeded = user.used >= user.maxRequests;
+    const chatExceeded = chat.used >= chat.maxRequests;
+    const downgradeReason: UsageSnapshot['downgradeReason'] = userExceeded &&
+            chatExceeded
+        ? 'both'
+        : userExceeded
+        ? 'user'
+        : chatExceeded
+        ? 'chat'
+        : 'none';
+
+    return {
+        tier,
+        downgraded: downgradeReason !== 'none',
+        downgradeReason,
+        user,
+        chat,
+    };
+}
+
+export function renderProgressBar(
+    used: number,
+    maxRequests: number,
+    width = 16,
+): string {
+    if (width < 1) return '';
+    const ratio = clampRatio(used, maxRequests);
+    const filled = Math.round(ratio * width);
+    return `${'█'.repeat(filled)}${'░'.repeat(width - filled)}`;
+}

--- a/lib/web/config-policy.ts
+++ b/lib/web/config-policy.ts
@@ -154,6 +154,9 @@ export function sanitizeChatOverrideForRole(
         blacklistedReactions: override.blacklistedReactions,
         nepons: override.nepons,
         responseDelay: override.responseDelay,
+        requestWindowPerChat: role === 'admin'
+            ? override.requestWindowPerChat
+            : undefined,
     };
 
     if (next.blacklistedReactions) {

--- a/lib/web/server.ts
+++ b/lib/web/server.ts
@@ -30,6 +30,7 @@ import logger from '../logger.ts';
 import { type BotCharacter, ChatMemory, Memory } from '../memory.ts';
 import { chatMembers, chats } from '../db/schema.ts';
 import { ALLOWED_REACTIONS } from '../telegram/reactions.ts';
+import { getUsageSnapshot, renderProgressBar } from '../telegram/usage-window.ts';
 
 interface RuntimeConfigAccess {
     getBotToken: () => string;
@@ -62,6 +63,19 @@ interface CurrentCharacterPayload {
 interface ChatInternalsPayload {
     summary: string;
     personalNotes: string;
+}
+
+interface UsageWindowStatusPayload {
+    tier: 'free' | 'trusted';
+    downgraded: boolean;
+    userUsed: number;
+    userMax: number;
+    userWindowMinutes: number;
+    userBar: string;
+    chatUsed: number;
+    chatMax: number;
+    chatWindowMinutes: number;
+    chatBar: string;
 }
 
 function projectCurrentCharacter(
@@ -331,6 +345,7 @@ export function startWebServer(options: StartWebServerOptions) {
                 let canEditChat = false;
                 let canEditChatInternals = false;
                 let chatInternalsPayload: ChatInternalsPayload | undefined;
+                let usageWindowStatus: UsageWindowStatusPayload | undefined;
 
                 if (chatId !== undefined && Number.isFinite(chatId)) {
                     canEditChat = await canEditChatConfig(
@@ -379,6 +394,40 @@ export function startWebServer(options: StartWebServerOptions) {
                             serializedEffectiveConfig,
                             role,
                         );
+
+                        if (userId) {
+                            const usageSnapshot = await getUsageSnapshot(
+                                options.memory.db,
+                                {
+                                    config: globalConfig,
+                                    chatId,
+                                    userId,
+                                    chatOverride,
+                                },
+                            );
+                            usageWindowStatus = {
+                                tier: usageSnapshot.tier,
+                                downgraded: usageSnapshot.downgraded,
+                                userUsed: usageSnapshot.user.used,
+                                userMax: usageSnapshot.user.maxRequests,
+                                userWindowMinutes:
+                                    usageSnapshot.user.windowMinutes,
+                                userBar: renderProgressBar(
+                                    usageSnapshot.user.used,
+                                    usageSnapshot.user.maxRequests,
+                                    16,
+                                ),
+                                chatUsed: usageSnapshot.chat.used,
+                                chatMax: usageSnapshot.chat.maxRequests,
+                                chatWindowMinutes:
+                                    usageSnapshot.chat.windowMinutes,
+                                chatBar: renderProgressBar(
+                                    usageSnapshot.chat.used,
+                                    usageSnapshot.chat.maxRequests,
+                                    16,
+                                ),
+                            };
+                        }
                     }
                 }
 
@@ -399,6 +448,7 @@ export function startWebServer(options: StartWebServerOptions) {
                     effectiveConfigPayload,
                     currentCharacter,
                     chatInternalsPayload,
+                    usageWindowStatus,
                 });
             }
 

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -149,3 +149,10 @@ config-open-widget = Open config widget
 config-open-global = Open global bot configuration
 config-open-chat = Open current chat configuration
 config-widget-unavailable = Config widget is unavailable right now
+
+# Usage window
+usage-title = Usage window ({ $tier } tier)
+usage-user-window = Per-user
+usage-chat-window = Per-chat
+usage-downgraded = Cost mode is active. Expensive features are disabled and model switched to { $model }.
+usage-normal = Normal mode is active.

--- a/locales/hi.ftl
+++ b/locales/hi.ftl
@@ -149,3 +149,10 @@ config-open-widget = कॉन्फिग विजेट खोलो
 config-open-global = बॉट का ग्लोबल कॉन्फिग खोलो
 config-open-chat = इस चैट का कॉन्फिग खोलो
 config-widget-unavailable = कॉन्फिग विजेट अभी उपलब्ध नहीं है
+
+# Usage window
+usage-title = Usage window ({ $tier } tier)
+usage-user-window = Per-user
+usage-chat-window = Per-chat
+usage-downgraded = Cost mode is active. Expensive features are disabled and model switched to { $model }.
+usage-normal = Normal mode is active.

--- a/locales/id.ftl
+++ b/locales/id.ftl
@@ -149,3 +149,10 @@ config-open-widget = Buka widget konfigurasi
 config-open-global = Buka konfigurasi global bot
 config-open-chat = Buka konfigurasi chat saat ini
 config-widget-unavailable = Widget konfigurasi sedang tidak tersedia
+
+# Usage window
+usage-title = Usage window ({ $tier } tier)
+usage-user-window = Per-user
+usage-chat-window = Per-chat
+usage-downgraded = Cost mode is active. Expensive features are disabled and model switched to { $model }.
+usage-normal = Normal mode is active.

--- a/locales/pt.ftl
+++ b/locales/pt.ftl
@@ -149,3 +149,10 @@ config-open-widget = Abrir widget de configuração
 config-open-global = Abrir configuração global do bot
 config-open-chat = Abrir configuração do chat atual
 config-widget-unavailable = Widget de configuração indisponível agora
+
+# Usage window
+usage-title = Usage window ({ $tier } tier)
+usage-user-window = Per-user
+usage-chat-window = Per-chat
+usage-downgraded = Cost mode is active. Expensive features are disabled and model switched to { $model }.
+usage-normal = Normal mode is active.

--- a/locales/ru.ftl
+++ b/locales/ru.ftl
@@ -149,3 +149,10 @@ config-open-widget = Открыть виджет настроек
 config-open-global = Открыть глобальную конфигурацию бота
 config-open-chat = Открыть конфигурацию текущего чата
 config-widget-unavailable = Виджет конфигурации сейчас недоступен
+
+# Usage window
+usage-title = Usage window ({ $tier } tier)
+usage-user-window = Per-user
+usage-chat-window = Per-chat
+usage-downgraded = Cost mode is active. Expensive features are disabled and model switched to { $model }.
+usage-normal = Normal mode is active.

--- a/locales/uk.ftl
+++ b/locales/uk.ftl
@@ -149,3 +149,10 @@ config-open-widget = Відкрити віджет налаштувань
 config-open-global = Відкрити глобальну конфігурацію бота
 config-open-chat = Відкрити конфігурацію поточного чату
 config-widget-unavailable = Віджет конфігурації зараз недоступний
+
+# Usage window
+usage-title = Usage window ({ $tier } tier)
+usage-user-window = Per-user
+usage-chat-window = Per-chat
+usage-downgraded = Cost mode is active. Expensive features are disabled and model switched to { $model }.
+usage-normal = Normal mode is active.

--- a/widget/src/App.svelte
+++ b/widget/src/App.svelte
@@ -237,6 +237,7 @@
             canViewGlobal={controller.canViewGlobal}
             role={controller.role}
             availableChats={controller.availableChats}
+            usageWindowStatus={controller.usageWindowStatus}
             onReload={reloadWithFeedback}
             isReloading={isReloading}
             isLoading={controller.isLoading}
@@ -284,6 +285,7 @@
                                 currentCharacter={controller.currentCharacter}
                                 canEditChatInternals={controller.canEditChatInternals}
                                 canConfigureTrustedSettings={controller.canConfigureTrustedSettings}
+                                canEditWindowOverrides={controller.role === 'admin'}
                                 overriddenFieldPaths={overriddenFieldPaths}
                                 searchQuery={settingsSearch}
                             />

--- a/widget/src/lib/components/config/ChatOverrideForm.svelte
+++ b/widget/src/lib/components/config/ChatOverrideForm.svelte
@@ -24,6 +24,7 @@
         currentCharacter?: CurrentCharacterPayload;
         canEditChatInternals: boolean;
         canConfigureTrustedSettings: boolean;
+        canEditWindowOverrides: boolean;
         overriddenFieldPaths: string[];
         searchQuery: string;
     }
@@ -37,6 +38,7 @@
         currentCharacter,
         canEditChatInternals,
         canConfigureTrustedSettings,
+        canEditWindowOverrides,
         overriddenFieldPaths = [],
         searchQuery = '',
     }: Props = $props();
@@ -104,6 +106,10 @@
             'reply method',
             'max reply length',
             'attachment byte limit',
+            'free tier per-chat max requests',
+            'free tier per-chat window minutes',
+            'trusted tier per-chat max requests',
+            'trusted tier per-chat window minutes',
             'include attachments in history',
         ),
     );
@@ -579,6 +585,56 @@
                             hidden={!matchesBlockItem('advanced', 'include attachments in history')}
                             bind:checked={config.ai.includeAttachmentsInHistory}
                         />
+                        {#if canEditWindowOverrides}
+                            <SettingInputField
+                                id="c-req-free-chat-max"
+                                type="number"
+                                label="Free tier per-chat max requests"
+                                description="Chat-wide free-tier limit before cost mode."
+                                sourceState={{
+                                    overridden: isOverridden('requestWindowPerChat.free.maxRequests'),
+                                    label: sourceStateText('requestWindowPerChat.free.maxRequests'),
+                                }}
+                                hidden={!matchesBlockItem('advanced', 'free tier per-chat max requests')}
+                                bind:value={config.requestWindowPerChat.free.maxRequests}
+                            />
+                            <SettingInputField
+                                id="c-req-free-chat-window"
+                                type="number"
+                                label="Free tier per-chat window (minutes)"
+                                description="Rolling window for free-tier chat usage."
+                                sourceState={{
+                                    overridden: isOverridden('requestWindowPerChat.free.windowMinutes'),
+                                    label: sourceStateText('requestWindowPerChat.free.windowMinutes'),
+                                }}
+                                hidden={!matchesBlockItem('advanced', 'free tier per-chat window minutes')}
+                                bind:value={config.requestWindowPerChat.free.windowMinutes}
+                            />
+                            <SettingInputField
+                                id="c-req-trusted-chat-max"
+                                type="number"
+                                label="Trusted tier per-chat max requests"
+                                description="Chat-wide trusted-tier limit before cost mode."
+                                sourceState={{
+                                    overridden: isOverridden('requestWindowPerChat.trusted.maxRequests'),
+                                    label: sourceStateText('requestWindowPerChat.trusted.maxRequests'),
+                                }}
+                                hidden={!matchesBlockItem('advanced', 'trusted tier per-chat max requests')}
+                                bind:value={config.requestWindowPerChat.trusted.maxRequests}
+                            />
+                            <SettingInputField
+                                id="c-req-trusted-chat-window"
+                                type="number"
+                                label="Trusted tier per-chat window (minutes)"
+                                description="Rolling window for trusted-tier chat usage."
+                                sourceState={{
+                                    overridden: isOverridden('requestWindowPerChat.trusted.windowMinutes'),
+                                    label: sourceStateText('requestWindowPerChat.trusted.windowMinutes'),
+                                }}
+                                hidden={!matchesBlockItem('advanced', 'trusted tier per-chat window minutes')}
+                                bind:value={config.requestWindowPerChat.trusted.windowMinutes}
+                            />
+                        {/if}
                     </div>
                 </details>
             {/if}

--- a/widget/src/lib/components/config/ConfigToolbar.svelte
+++ b/widget/src/lib/components/config/ConfigToolbar.svelte
@@ -7,6 +7,7 @@
         AvailableChat,
         ConfigRole,
         ConfigScope,
+        UsageWindowStatus,
     } from '$lib/config/model';
 
     interface Props {
@@ -16,6 +17,7 @@
         canViewGlobal: boolean;
         role: ConfigRole;
         availableChats: AvailableChat[];
+        usageWindowStatus?: UsageWindowStatus;
         onReload: () => void;
         isReloading: boolean;
         isLoading: boolean;
@@ -28,6 +30,7 @@
         canViewGlobal,
         role,
         availableChats,
+        usageWindowStatus,
         onReload,
         isReloading = false,
         isLoading = false,
@@ -84,6 +87,23 @@
     </div>
 
     <div class="space-y-4">
+        {#if usageWindowStatus}
+            <div class="space-y-1 rounded-md border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                <div class="flex items-center justify-between gap-2">
+                    <span class="font-medium text-foreground">
+                        Usage ({usageWindowStatus.tier})
+                    </span>
+                    {#if usageWindowStatus.downgraded}
+                        <span class="rounded bg-amber-500/20 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                            cost mode
+                        </span>
+                    {/if}
+                </div>
+                <p>Per-user: <span class="font-mono">{usageWindowStatus.userBar}</span> {usageWindowStatus.userUsed}/{usageWindowStatus.userMax} ({usageWindowStatus.userWindowMinutes}m)</p>
+                <p>Per-chat: <span class="font-mono">{usageWindowStatus.chatBar}</span> {usageWindowStatus.chatUsed}/{usageWindowStatus.chatMax} ({usageWindowStatus.chatWindowMinutes}m)</p>
+            </div>
+        {/if}
+
         <div class="grid gap-3" class:md:grid-cols-3={canViewGlobal} class:md:grid-cols-2={!canViewGlobal}>
             {#if canViewGlobal}
                 <div class="space-y-2">

--- a/widget/src/lib/components/config/GlobalConfigForm.svelte
+++ b/widget/src/lib/components/config/GlobalConfigForm.svelte
@@ -105,6 +105,21 @@
             'memory update frequency',
             'max reply length',
             'attachment byte limit',
+            'free user per-user max requests',
+            'free user per-user window minutes',
+            'free user per-chat max requests',
+            'free user per-chat window minutes',
+            'trusted user per-user max requests',
+            'trusted user per-user window minutes',
+            'trusted user per-chat max requests',
+            'trusted user per-chat window minutes',
+            'downgrade model',
+            'downgraded messages to pass',
+            'downgraded bytes limit',
+            'disable long context',
+            'disable notes',
+            'disable attachments',
+            'disable memory',
             'include attachments in history',
         ),
     );
@@ -553,6 +568,121 @@
                         description="Adds attachment text to model context when possible."
                         hidden={!matchesBlockItem('advanced', 'include attachments in history')}
                         bind:checked={config.ai.includeAttachmentsInHistory}
+                    />
+                    <SettingInputField
+                        id="g-req-free-user-max"
+                        type="number"
+                        label="Free user per-user max requests"
+                        description="Switches to downgrade mode when this limit is reached."
+                        hidden={!matchesBlockItem('advanced', 'free user per-user max requests')}
+                        bind:value={config.requestWindow.free.perUser.maxRequests}
+                    />
+                    <SettingInputField
+                        id="g-req-free-user-window"
+                        type="number"
+                        label="Free user per-user window (minutes)"
+                        description="Rolling window for free user personal usage."
+                        hidden={!matchesBlockItem('advanced', 'free user per-user window minutes')}
+                        bind:value={config.requestWindow.free.perUser.windowMinutes}
+                    />
+                    <SettingInputField
+                        id="g-req-free-chat-max"
+                        type="number"
+                        label="Free user per-chat max requests"
+                        description="Chat-wide limit for free tier before downgrade mode."
+                        hidden={!matchesBlockItem('advanced', 'free user per-chat max requests')}
+                        bind:value={config.requestWindow.free.perChat.maxRequests}
+                    />
+                    <SettingInputField
+                        id="g-req-free-chat-window"
+                        type="number"
+                        label="Free user per-chat window (minutes)"
+                        description="Rolling window for free tier chat usage."
+                        hidden={!matchesBlockItem('advanced', 'free user per-chat window minutes')}
+                        bind:value={config.requestWindow.free.perChat.windowMinutes}
+                    />
+                    <SettingInputField
+                        id="g-req-trusted-user-max"
+                        type="number"
+                        label="Trusted user per-user max requests"
+                        description="Personal limit for trusted tier before downgrade mode."
+                        hidden={!matchesBlockItem('advanced', 'trusted user per-user max requests')}
+                        bind:value={config.requestWindow.trusted.perUser.maxRequests}
+                    />
+                    <SettingInputField
+                        id="g-req-trusted-user-window"
+                        type="number"
+                        label="Trusted user per-user window (minutes)"
+                        description="Rolling window for trusted user personal usage."
+                        hidden={!matchesBlockItem('advanced', 'trusted user per-user window minutes')}
+                        bind:value={config.requestWindow.trusted.perUser.windowMinutes}
+                    />
+                    <SettingInputField
+                        id="g-req-trusted-chat-max"
+                        type="number"
+                        label="Trusted user per-chat max requests"
+                        description="Chat-wide limit for trusted tier before downgrade mode."
+                        hidden={!matchesBlockItem('advanced', 'trusted user per-chat max requests')}
+                        bind:value={config.requestWindow.trusted.perChat.maxRequests}
+                    />
+                    <SettingInputField
+                        id="g-req-trusted-chat-window"
+                        type="number"
+                        label="Trusted user per-chat window (minutes)"
+                        description="Rolling window for trusted tier chat usage."
+                        hidden={!matchesBlockItem('advanced', 'trusted user per-chat window minutes')}
+                        bind:value={config.requestWindow.trusted.perChat.windowMinutes}
+                    />
+                    <SettingInputField
+                        id="g-req-downgrade-model"
+                        label="Downgrade model"
+                        description="Model used when either window limit is exhausted."
+                        hidden={!matchesBlockItem('advanced', 'downgrade model')}
+                        bind:value={config.requestWindow.downgradeModel}
+                    />
+                    <SettingInputField
+                        id="g-req-downgrade-messages"
+                        type="number"
+                        label="Downgraded messages to pass"
+                        description="Maximum messages included when long context is disabled."
+                        hidden={!matchesBlockItem('advanced', 'downgraded messages to pass')}
+                        bind:value={config.requestWindow.downgradeMessagesToPass}
+                    />
+                    <SettingInputField
+                        id="g-req-downgrade-bytes"
+                        type="number"
+                        label="Downgraded bytes limit"
+                        description="Max bytes included when long context is disabled."
+                        hidden={!matchesBlockItem('advanced', 'downgraded bytes limit')}
+                        bind:value={config.requestWindow.downgradeBytesLimit}
+                    />
+                    <SettingToggleField
+                        id="g-req-disable-long-context"
+                        label="Disable long context in cost mode"
+                        description="Reduces history size when windows are exhausted."
+                        hidden={!matchesBlockItem('advanced', 'disable long context')}
+                        bind:checked={config.requestWindow.disableLongContext}
+                    />
+                    <SettingToggleField
+                        id="g-req-disable-notes"
+                        label="Disable notes in cost mode"
+                        description="Skips notes generation and inclusion while downgraded."
+                        hidden={!matchesBlockItem('advanced', 'disable notes')}
+                        bind:checked={config.requestWindow.disableNotes}
+                    />
+                    <SettingToggleField
+                        id="g-req-disable-attachments"
+                        label="Disable attachments in cost mode"
+                        description="Excludes attachments from history while downgraded."
+                        hidden={!matchesBlockItem('advanced', 'disable attachments')}
+                        bind:checked={config.requestWindow.disableAttachments}
+                    />
+                    <SettingToggleField
+                        id="g-req-disable-memory"
+                        label="Disable memory in cost mode"
+                        description="Skips memory generation and inclusion while downgraded."
+                        hidden={!matchesBlockItem('advanced', 'disable memory')}
+                        bind:checked={config.requestWindow.disableMemory}
                     />
                 </div>
             </details>

--- a/widget/src/lib/config/controller.svelte.ts
+++ b/widget/src/lib/config/controller.svelte.ts
@@ -21,10 +21,12 @@ import {
   fromUnknownChatOverride,
   fromUnknownCurrentCharacter,
   fromUnknownGlobal,
+  fromUnknownUsageWindowStatus,
   type GlobalFormText,
   globalTextFromConfig,
   parseChatIdFromStartParam,
   type ResolvedChatOverridePayload,
+  type UsageWindowStatus,
 } from "./model";
 
 function initialSearchParams(): URLSearchParams {
@@ -64,6 +66,7 @@ export class ConfigController {
   chatInternals = $state<ChatInternalsPayload>(
     fromUnknownChatInternals(undefined),
   );
+  usageWindowStatus = $state<UsageWindowStatus | undefined>(undefined);
 
   globalConfig = $state(defaultGlobalConfig());
   globalText = $state<GlobalFormText>({
@@ -177,6 +180,9 @@ export class ConfigController {
     );
     this.chatInternals = fromUnknownChatInternals(
       data.chatInternalsPayload,
+    );
+    this.usageWindowStatus = fromUnknownUsageWindowStatus(
+      data.usageWindowStatus,
     );
 
     if (!this.canViewGlobal && this.scope === "global") {

--- a/widget/src/lib/config/model.ts
+++ b/widget/src/lib/config/model.ts
@@ -8,6 +8,51 @@ export interface AvailableChat {
   type: "private" | "group" | "supergroup" | "channel";
 }
 
+export interface UsageWindowStatus {
+  tier: "free" | "trusted";
+  downgraded: boolean;
+  userUsed: number;
+  userMax: number;
+  userWindowMinutes: number;
+  userBar: string;
+  chatUsed: number;
+  chatMax: number;
+  chatWindowMinutes: number;
+  chatBar: string;
+}
+
+export interface RequestWindowLimit {
+  maxRequests: number;
+  windowMinutes: number;
+}
+
+export interface RequestWindowTier {
+  perUser: RequestWindowLimit;
+  perChat: RequestWindowLimit;
+}
+
+export interface RequestWindowConfig {
+  free: RequestWindowTier;
+  trusted: RequestWindowTier;
+  downgradeModel: string;
+  disableLongContext: boolean;
+  downgradeMessagesToPass: number;
+  downgradeBytesLimit: number;
+  disableNotes: boolean;
+  disableAttachments: boolean;
+  disableMemory: boolean;
+}
+
+export interface RequestWindowLimitOverride {
+  maxRequests?: number;
+  windowMinutes?: number;
+}
+
+export interface RequestWindowPerChatOverride {
+  free?: RequestWindowLimitOverride;
+  trusted?: RequestWindowLimitOverride;
+}
+
 export interface BootstrapResponse {
   role: ConfigRole;
   categories: string[];
@@ -23,6 +68,7 @@ export interface BootstrapResponse {
   effectiveConfigPayload?: unknown;
   currentCharacter?: unknown;
   chatInternalsPayload?: unknown;
+  usageWindowStatus?: unknown;
 }
 
 export interface CurrentCharacterPayload {
@@ -156,6 +202,7 @@ export interface UserConfigPayload {
   chatLastUseNotes: number;
   chatLastUseMemory: number;
   responseDelay: number;
+  requestWindow: RequestWindowConfig;
 }
 
 export interface ChatOverridePayload {
@@ -169,6 +216,7 @@ export interface ChatOverridePayload {
   blacklistedReactions?: string[];
   nepons?: string[];
   responseDelay?: number;
+  requestWindowPerChat?: RequestWindowPerChatOverride;
 }
 
 function normalizeThinkingConfig(value: unknown): GoogleThinkingConfig {
@@ -247,6 +295,10 @@ export interface ResolvedChatOverridePayload {
   blacklistedReactions: string[];
   nepons: string[];
   responseDelay: number;
+  requestWindowPerChat: {
+    free: RequestWindowLimit;
+    trusted: RequestWindowLimit;
+  };
 }
 
 export interface GlobalFormText {
@@ -390,6 +442,149 @@ export function defaultChatEditableAiConfig(
   };
 }
 
+function defaultRequestWindowLimit(
+  maxRequests: number,
+  windowMinutes: number,
+): RequestWindowLimit {
+  return { maxRequests, windowMinutes };
+}
+
+export function defaultRequestWindowConfig(): RequestWindowConfig {
+  return {
+    free: {
+      perUser: defaultRequestWindowLimit(30, 180),
+      perChat: defaultRequestWindowLimit(120, 180),
+    },
+    trusted: {
+      perUser: defaultRequestWindowLimit(300, 180),
+      perChat: defaultRequestWindowLimit(1200, 180),
+    },
+    downgradeModel: "",
+    disableLongContext: true,
+    downgradeMessagesToPass: 4,
+    downgradeBytesLimit: 1024 * 1024,
+    disableNotes: true,
+    disableAttachments: true,
+    disableMemory: true,
+  };
+}
+
+function normalizeRequestWindowLimit(
+  value: unknown,
+  base: RequestWindowLimit,
+): RequestWindowLimit {
+  if (!value || typeof value !== "object") {
+    return { ...base };
+  }
+
+  const obj = value as Partial<RequestWindowLimit>;
+  return {
+    maxRequests: typeof obj.maxRequests === "number"
+      ? obj.maxRequests
+      : base.maxRequests,
+    windowMinutes: typeof obj.windowMinutes === "number"
+      ? obj.windowMinutes
+      : base.windowMinutes,
+  };
+}
+
+function normalizeRequestWindowConfig(value: unknown): RequestWindowConfig {
+  const base = defaultRequestWindowConfig();
+  if (!value || typeof value !== "object") {
+    return base;
+  }
+
+  const obj = value as Partial<RequestWindowConfig>;
+  return {
+    free: {
+      perUser: normalizeRequestWindowLimit(obj.free?.perUser, base.free.perUser),
+      perChat: normalizeRequestWindowLimit(obj.free?.perChat, base.free.perChat),
+    },
+    trusted: {
+      perUser: normalizeRequestWindowLimit(
+        obj.trusted?.perUser,
+        base.trusted.perUser,
+      ),
+      perChat: normalizeRequestWindowLimit(
+        obj.trusted?.perChat,
+        base.trusted.perChat,
+      ),
+    },
+    downgradeModel: typeof obj.downgradeModel === "string"
+      ? obj.downgradeModel
+      : base.downgradeModel,
+    disableLongContext: typeof obj.disableLongContext === "boolean"
+      ? obj.disableLongContext
+      : base.disableLongContext,
+    downgradeMessagesToPass: typeof obj.downgradeMessagesToPass === "number"
+      ? obj.downgradeMessagesToPass
+      : base.downgradeMessagesToPass,
+    downgradeBytesLimit: typeof obj.downgradeBytesLimit === "number"
+      ? obj.downgradeBytesLimit
+      : base.downgradeBytesLimit,
+    disableNotes: typeof obj.disableNotes === "boolean"
+      ? obj.disableNotes
+      : base.disableNotes,
+    disableAttachments: typeof obj.disableAttachments === "boolean"
+      ? obj.disableAttachments
+      : base.disableAttachments,
+    disableMemory: typeof obj.disableMemory === "boolean"
+      ? obj.disableMemory
+      : base.disableMemory,
+  };
+}
+
+function normalizeRequestWindowPerChatOverride(
+  value: unknown,
+): RequestWindowPerChatOverride {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const obj = value as Partial<RequestWindowPerChatOverride>;
+  const normalizeLimit = (
+    raw: unknown,
+  ): RequestWindowLimitOverride | undefined => {
+    if (!raw || typeof raw !== "object") {
+      return undefined;
+    }
+    const entry = raw as Partial<RequestWindowLimitOverride>;
+    const next: RequestWindowLimitOverride = {};
+    if (typeof entry.maxRequests === "number") {
+      next.maxRequests = entry.maxRequests;
+    }
+    if (typeof entry.windowMinutes === "number") {
+      next.windowMinutes = entry.windowMinutes;
+    }
+    return Object.keys(next).length > 0 ? next : undefined;
+  };
+
+  return {
+    free: normalizeLimit(obj.free),
+    trusted: normalizeLimit(obj.trusted),
+  };
+}
+
+function resolveRequestWindowPerChat(
+  globalConfig: RequestWindowConfig,
+  override?: RequestWindowPerChatOverride,
+): { free: RequestWindowLimit; trusted: RequestWindowLimit } {
+  return {
+    free: {
+      maxRequests: override?.free?.maxRequests ??
+        globalConfig.free.perChat.maxRequests,
+      windowMinutes: override?.free?.windowMinutes ??
+        globalConfig.free.perChat.windowMinutes,
+    },
+    trusted: {
+      maxRequests: override?.trusted?.maxRequests ??
+        globalConfig.trusted.perChat.maxRequests,
+      windowMinutes: override?.trusted?.windowMinutes ??
+        globalConfig.trusted.perChat.windowMinutes,
+    },
+  };
+}
+
 export function defaultGlobalConfig(): UserConfigPayload {
   return {
     ai: defaultAiConfig(),
@@ -411,6 +606,7 @@ export function defaultGlobalConfig(): UserConfigPayload {
     chatLastUseNotes: 3,
     chatLastUseMemory: 2,
     responseDelay: 1,
+    requestWindow: defaultRequestWindowConfig(),
   };
 }
 
@@ -529,6 +725,7 @@ export function fromUnknownGlobal(payload: unknown): UserConfigPayload {
       )
       : [],
     availableModels: normalizeModels(obj.availableModels),
+    requestWindow: normalizeRequestWindowConfig(obj.requestWindow),
   };
 }
 
@@ -541,6 +738,9 @@ export function fromUnknownChatOverride(
     : {};
   const baseAi = defaultChatEditableAiConfig(global.ai);
   const overrideAi = obj.ai ?? {};
+  const requestWindowPerChat = normalizeRequestWindowPerChatOverride(
+    obj.requestWindowPerChat,
+  );
 
   return {
     ai: {
@@ -560,6 +760,10 @@ export function fromUnknownChatOverride(
       global.blacklistedReactions,
     nepons: obj.nepons ?? global.nepons,
     responseDelay: obj.responseDelay ?? global.responseDelay,
+    requestWindowPerChat: resolveRequestWindowPerChat(
+      global.requestWindow,
+      requestWindowPerChat,
+    ),
   };
 }
 
@@ -616,6 +820,44 @@ export function fromUnknownChatInternals(
     personalNotes: typeof obj.personalNotes === "string"
       ? obj.personalNotes
       : base.personalNotes,
+  };
+}
+
+export function fromUnknownUsageWindowStatus(
+  payload: unknown,
+): UsageWindowStatus | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const obj = payload as Partial<UsageWindowStatus>;
+  if (obj.tier !== "free" && obj.tier !== "trusted") {
+    return undefined;
+  }
+  if (
+    typeof obj.userUsed !== "number" ||
+    typeof obj.userMax !== "number" ||
+    typeof obj.userWindowMinutes !== "number" ||
+    typeof obj.userBar !== "string" ||
+    typeof obj.chatUsed !== "number" ||
+    typeof obj.chatMax !== "number" ||
+    typeof obj.chatWindowMinutes !== "number" ||
+    typeof obj.chatBar !== "string" ||
+    typeof obj.downgraded !== "boolean"
+  ) {
+    return undefined;
+  }
+
+  return {
+    tier: obj.tier,
+    downgraded: obj.downgraded,
+    userUsed: obj.userUsed,
+    userMax: obj.userMax,
+    userWindowMinutes: obj.userWindowMinutes,
+    userBar: obj.userBar,
+    chatUsed: obj.chatUsed,
+    chatMax: obj.chatMax,
+    chatWindowMinutes: obj.chatWindowMinutes,
+    chatBar: obj.chatBar,
   };
 }
 
@@ -717,6 +959,33 @@ export function buildChatPayload(
     payload.responseDelay = config.responseDelay;
   }
 
+  const requestWindowPerChat: RequestWindowPerChatOverride = {};
+  if (
+    config.requestWindowPerChat.free.maxRequests !==
+      base.requestWindowPerChat.free.maxRequests ||
+    config.requestWindowPerChat.free.windowMinutes !==
+      base.requestWindowPerChat.free.windowMinutes
+  ) {
+    requestWindowPerChat.free = {
+      maxRequests: config.requestWindowPerChat.free.maxRequests,
+      windowMinutes: config.requestWindowPerChat.free.windowMinutes,
+    };
+  }
+  if (
+    config.requestWindowPerChat.trusted.maxRequests !==
+      base.requestWindowPerChat.trusted.maxRequests ||
+    config.requestWindowPerChat.trusted.windowMinutes !==
+      base.requestWindowPerChat.trusted.windowMinutes
+  ) {
+    requestWindowPerChat.trusted = {
+      maxRequests: config.requestWindowPerChat.trusted.maxRequests,
+      windowMinutes: config.requestWindowPerChat.trusted.windowMinutes,
+    };
+  }
+  if (Object.keys(requestWindowPerChat).length > 0) {
+    payload.requestWindowPerChat = requestWindowPerChat;
+  }
+
   const aiPayload: Partial<ChatEditableAiPayload> = {};
   if (config.ai.model !== base.ai.model) aiPayload.model = config.ai.model;
   if (config.ai.temperature !== base.ai.temperature) {
@@ -801,6 +1070,18 @@ export function collectChatOverridePaths(
   if (payload.blacklistedReactions) paths.push("blacklistedReactions");
   if (payload.nepons) paths.push("nepons");
   if (payload.responseDelay !== undefined) paths.push("responseDelay");
+  if (payload.requestWindowPerChat?.free?.maxRequests !== undefined) {
+    paths.push("requestWindowPerChat.free.maxRequests");
+  }
+  if (payload.requestWindowPerChat?.free?.windowMinutes !== undefined) {
+    paths.push("requestWindowPerChat.free.windowMinutes");
+  }
+  if (payload.requestWindowPerChat?.trusted?.maxRequests !== undefined) {
+    paths.push("requestWindowPerChat.trusted.maxRequests");
+  }
+  if (payload.requestWindowPerChat?.trusted?.windowMinutes !== undefined) {
+    paths.push("requestWindowPerChat.trusted.windowMinutes");
+  }
 
   if (!payload.ai) {
     return paths;


### PR DESCRIPTION
## Summary
- add a configurable request-window policy with `free` and `trusted` tiers, each with per-user and per-chat rolling limits
- apply downgrade mode when either limit is exhausted (switch model and disable expensive features: long context, notes, attachments, memory)
- add `/usage` command and widget top-bar usage indicators, plus admin chat-override controls for per-chat limits

## Verification
- deno check --allow-import main.ts
- deno lint
- AI_TOKEN=\"test\" deno test -A
- widget: deno task check && deno task lint && deno task build