### PR TITLE
Add Prometheus metrics endpoint and backend instrumentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,4 @@ We are building this together. When you learn something non-obvious but actually
 
 - Widget ESLint enables `svelte/prefer-svelte-reactivity`: avoid creating mutable `Set`/`Map` instances inside component scripts unless using Svelte reactive alternatives.
 - Widget uses Bits UI select wrappers in `widget/src/lib/components/ui/select`: prefer those over native `<select>` for mobile UX; use `onValueChange` for side effects like reload-on-select.
+- Backend exposes Prometheus metrics at `GET /metrics` from `lib/web/server.ts`; keep metric labels low-cardinality (use route templates, avoid user/chat IDs).

--- a/lib/ai/language-protocol.ts
+++ b/lib/ai/language-protocol.ts
@@ -1,4 +1,10 @@
+function normalizeLocaleCode(localeCode: string): string {
+    const cleaned = localeCode.trim().toLowerCase().replaceAll('_', '-');
+    return cleaned.split('-')[0] ?? cleaned;
+}
+
 function getLanguageName(localeCode: string): string {
+    const normalizedLocale = normalizeLocaleCode(localeCode);
     const map: Record<string, string> = {
         ru: 'Russian',
         uk: 'Ukrainian',
@@ -7,7 +13,7 @@ function getLanguageName(localeCode: string): string {
         hi: 'Hindi',
         id: 'Indonesian',
     };
-    return map[localeCode] ?? 'the chat language';
+    return map[normalizedLocale] ?? 'the chat language';
 }
 
 export function buildLanguageProtocol(defaultLocale: string): string {

--- a/lib/ai/language-protocol_test.ts
+++ b/lib/ai/language-protocol_test.ts
@@ -6,6 +6,11 @@ Deno.test('buildLanguageProtocol uses mapped language name', () => {
     assertStringIncludes(protocol, 'Default to Russian language');
 });
 
+Deno.test('buildLanguageProtocol supports region-specific locale codes', () => {
+    const protocol = buildLanguageProtocol('ru-RU');
+    assertStringIncludes(protocol, 'Default to Russian language');
+});
+
 Deno.test('buildLanguageProtocol falls back to generic language', () => {
     const protocol = buildLanguageProtocol('zz');
     assertStringIncludes(protocol, 'Default to the chat language language');

--- a/lib/app/metrics.ts
+++ b/lib/app/metrics.ts
@@ -1,0 +1,384 @@
+type Labels = Record<string, string>;
+
+type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+interface MetricDefinition {
+    name: string;
+    help: string;
+    labelNames: string[];
+    kind: MetricKind;
+}
+
+function escapeLabelValue(value: string): string {
+    return value
+        .replaceAll('\\', '\\\\')
+        .replaceAll('\n', '\\n')
+        .replaceAll('"', '\\"');
+}
+
+function labelsKey(labelNames: string[], labels: Labels): string {
+    return labelNames.map((name) => `${name}=${labels[name] ?? ''}`).join('|');
+}
+
+function labelsSuffix(labelNames: string[], labels: Labels): string {
+    if (labelNames.length === 0) {
+        return '';
+    }
+
+    const pairs = labelNames.map((name) => {
+        const value = escapeLabelValue(labels[name] ?? '');
+        return `${name}="${value}"`;
+    });
+    return `{${pairs.join(',')}}`;
+}
+
+class Counter {
+    readonly definition: MetricDefinition;
+    #series = new Map<string, { labels: Labels; value: number }>();
+
+    constructor(name: string, help: string, labelNames: string[]) {
+        this.definition = {
+            name,
+            help,
+            labelNames,
+            kind: 'counter',
+        };
+    }
+
+    inc(labels: Labels = {}, value = 1): void {
+        if (!Number.isFinite(value) || value < 0) {
+            return;
+        }
+
+        const key = labelsKey(this.definition.labelNames, labels);
+        const existing = this.#series.get(key);
+        if (existing) {
+            existing.value += value;
+            return;
+        }
+
+        this.#series.set(key, {
+            labels: { ...labels },
+            value,
+        });
+    }
+
+    renderLines(): string[] {
+        const lines: string[] = [];
+        for (const { labels, value } of this.#series.values()) {
+            lines.push(
+                `${this.definition.name}${
+                    labelsSuffix(this.definition.labelNames, labels)
+                } ${value}`,
+            );
+        }
+        return lines;
+    }
+}
+
+class Gauge {
+    readonly definition: MetricDefinition;
+    #series = new Map<string, { labels: Labels; value: number }>();
+
+    constructor(name: string, help: string, labelNames: string[]) {
+        this.definition = {
+            name,
+            help,
+            labelNames,
+            kind: 'gauge',
+        };
+    }
+
+    set(labels: Labels = {}, value: number): void {
+        if (!Number.isFinite(value)) {
+            return;
+        }
+
+        const key = labelsKey(this.definition.labelNames, labels);
+        this.#series.set(key, {
+            labels: { ...labels },
+            value,
+        });
+    }
+
+    renderLines(): string[] {
+        const lines: string[] = [];
+        for (const { labels, value } of this.#series.values()) {
+            lines.push(
+                `${this.definition.name}${
+                    labelsSuffix(this.definition.labelNames, labels)
+                } ${value}`,
+            );
+        }
+        return lines;
+    }
+}
+
+class Histogram {
+    readonly definition: MetricDefinition;
+    readonly #buckets: number[];
+    #series = new Map<
+        string,
+        { labels: Labels; buckets: number[]; sum: number; count: number }
+    >();
+
+    constructor(
+        name: string,
+        help: string,
+        labelNames: string[],
+        buckets: number[],
+    ) {
+        this.definition = {
+            name,
+            help,
+            labelNames,
+            kind: 'histogram',
+        };
+        const unique = [...new Set(buckets)].filter((bucket) => bucket > 0)
+            .sort((left, right) => left - right);
+        this.#buckets = unique;
+    }
+
+    observe(labels: Labels = {}, value: number): void {
+        if (!Number.isFinite(value) || value < 0) {
+            return;
+        }
+
+        const key = labelsKey(this.definition.labelNames, labels);
+        let entry = this.#series.get(key);
+        if (!entry) {
+            entry = {
+                labels: { ...labels },
+                buckets: this.#buckets.map(() => 0),
+                sum: 0,
+                count: 0,
+            };
+            this.#series.set(key, entry);
+        }
+
+        entry.count += 1;
+        entry.sum += value;
+        for (let index = 0; index < this.#buckets.length; index++) {
+            if (value <= this.#buckets[index]) {
+                entry.buckets[index] += 1;
+            }
+        }
+    }
+
+    renderLines(): string[] {
+        const lines: string[] = [];
+        const labelNamesWithLe = [...this.definition.labelNames, 'le'];
+
+        for (const { labels, buckets, sum, count } of this.#series.values()) {
+            for (let index = 0; index < this.#buckets.length; index++) {
+                lines.push(
+                    `${this.definition.name}_bucket${
+                        labelsSuffix(labelNamesWithLe, {
+                            ...labels,
+                            le: String(this.#buckets[index]),
+                        })
+                    } ${buckets[index]}`,
+                );
+            }
+
+            lines.push(
+                `${this.definition.name}_bucket${
+                    labelsSuffix(labelNamesWithLe, { ...labels, le: '+Inf' })
+                } ${count}`,
+            );
+            lines.push(
+                `${this.definition.name}_sum${
+                    labelsSuffix(this.definition.labelNames, labels)
+                } ${sum}`,
+            );
+            lines.push(
+                `${this.definition.name}_count${
+                    labelsSuffix(this.definition.labelNames, labels)
+                } ${count}`,
+            );
+        }
+
+        return lines;
+    }
+}
+
+const metricFamilies: Array<Counter | Gauge | Histogram> = [];
+
+function registerMetric<T extends Counter | Gauge | Histogram>(metric: T): T {
+    metricFamilies.push(metric);
+    return metric;
+}
+
+export const httpRequestsTotal = registerMetric(
+    new Counter(
+        'slusha_http_requests_total',
+        'Total HTTP requests handled by the web server',
+        ['route', 'method', 'status_class'],
+    ),
+);
+
+export const httpRequestDurationSeconds = registerMetric(
+    new Histogram(
+        'slusha_http_request_duration_seconds',
+        'HTTP request duration in seconds',
+        ['route', 'method', 'status_class'],
+        [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+    ),
+);
+
+export const telegramUpdatesTotal = registerMetric(
+    new Counter(
+        'slusha_telegram_updates_total',
+        'Total Telegram updates processed by update type',
+        ['update_type'],
+    ),
+);
+
+export const telegramHandlerErrorsTotal = registerMetric(
+    new Counter(
+        'slusha_telegram_handler_errors_total',
+        'Total Telegram handler errors by update type and error kind',
+        ['update_type', 'error_type'],
+    ),
+);
+
+export const aiRequestsTotal = registerMetric(
+    new Counter(
+        'slusha_ai_requests_total',
+        'Total AI generation requests by task and model metadata',
+        ['task', 'provider', 'model_ref', 'reply_method', 'downgraded'],
+    ),
+);
+
+export const aiRequestDurationSeconds = registerMetric(
+    new Histogram(
+        'slusha_ai_request_duration_seconds',
+        'AI generation duration in seconds',
+        ['task', 'provider', 'model_ref', 'reply_method', 'downgraded'],
+        [0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60],
+    ),
+);
+
+export const aiFailuresTotal = registerMetric(
+    new Counter(
+        'slusha_ai_failures_total',
+        'Total AI generation failures by task and model metadata',
+        [
+            'task',
+            'provider',
+            'model_ref',
+            'reply_method',
+            'downgraded',
+            'error_type',
+        ],
+    ),
+);
+
+export const aiFinishReasonTotal = registerMetric(
+    new Counter(
+        'slusha_ai_finish_reason_total',
+        'Total AI completion finish reasons',
+        [
+            'task',
+            'provider',
+            'model_ref',
+            'reply_method',
+            'downgraded',
+            'finish_reason',
+        ],
+    ),
+);
+
+export const aiTokensTotal = registerMetric(
+    new Counter(
+        'slusha_ai_tokens_total',
+        'Total AI token usage by token type',
+        ['task', 'provider', 'model_ref', 'token_type'],
+    ),
+);
+
+export const rateLimitExceededTotal = registerMetric(
+    new Counter(
+        'slusha_rate_limit_exceeded_total',
+        'Total rate-limit exceed events by limiter and scope',
+        ['limiter', 'scope'],
+    ),
+);
+
+export const usageEventsRecordedTotal = registerMetric(
+    new Counter(
+        'slusha_usage_events_recorded_total',
+        'Total usage window events recorded',
+        ['has_user_id'],
+    ),
+);
+
+export const usageCleanupRunsTotal = registerMetric(
+    new Counter(
+        'slusha_usage_cleanup_runs_total',
+        'Total usage window cleanup runs',
+        [],
+    ),
+);
+
+export const usageDowngradedTotal = registerMetric(
+    new Counter(
+        'slusha_usage_downgraded_total',
+        'Total downgraded usage snapshots',
+        ['tier', 'reason'],
+    ),
+);
+
+export const processUptimeSeconds = registerMetric(
+    new Gauge(
+        'slusha_process_uptime_seconds',
+        'Process uptime in seconds',
+        [],
+    ),
+);
+
+export const processResidentMemoryBytes = registerMetric(
+    new Gauge(
+        'slusha_process_resident_memory_bytes',
+        'Process resident memory in bytes',
+        [],
+    ),
+);
+
+const processStartedAt = Date.now();
+
+export function statusClass(status: number): string {
+    const classCode = Math.floor(status / 100);
+    if (classCode < 1 || classCode > 5) {
+        return 'unknown';
+    }
+    return `${classCode}xx`;
+}
+
+export function errorType(error: unknown): string {
+    if (error instanceof Error) {
+        const name = error.name.trim();
+        return name.length > 0 ? name : 'Error';
+    }
+    return typeof error;
+}
+
+function updateProcessMetrics(): void {
+    processUptimeSeconds.set({}, (Date.now() - processStartedAt) / 1000);
+    processResidentMemoryBytes.set({}, Deno.memoryUsage().rss);
+}
+
+export function renderPrometheusMetrics(): string {
+    updateProcessMetrics();
+    const lines: string[] = [];
+    for (const metric of metricFamilies) {
+        lines.push(
+            `# HELP ${metric.definition.name} ${metric.definition.help}`,
+        );
+        lines.push(
+            `# TYPE ${metric.definition.name} ${metric.definition.kind}`,
+        );
+        lines.push(...metric.renderLines());
+    }
+    return `${lines.join('\n')}\n`;
+}

--- a/lib/telegram/bot/character.ts
+++ b/lib/telegram/bot/character.ts
@@ -19,8 +19,48 @@ import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 import { resolveGenerationPolicy } from '../../ai/generation-policy.ts';
 import { buildGenerationTelemetryMetadata } from '../../ai/telemetry-metadata.ts';
+import {
+    aiFailuresTotal,
+    aiFinishReasonTotal,
+    aiRequestDurationSeconds,
+    aiRequestsTotal,
+    aiTokensTotal,
+    errorType,
+    rateLimitExceededTotal,
+} from '../../app/metrics.ts';
 
 const bot = new Composer<SlushaContext>();
+
+function tokenCountFromUsage(usage: unknown, key: string): number | undefined {
+    if (typeof usage !== 'object' || usage === null) {
+        return undefined;
+    }
+
+    const raw = Reflect.get(usage, key);
+    return typeof raw === 'number' && Number.isFinite(raw) && raw >= 0
+        ? raw
+        : undefined;
+}
+
+function observeTokenUsage(labels: {
+    task: string;
+    provider: string;
+    model_ref: string;
+}, usage: unknown): void {
+    const inputTokens = tokenCountFromUsage(usage, 'inputTokens');
+    const outputTokens = tokenCountFromUsage(usage, 'outputTokens');
+    const totalTokens = tokenCountFromUsage(usage, 'totalTokens');
+
+    if (inputTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'input' }, inputTokens);
+    }
+    if (outputTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'output' }, outputTokens);
+    }
+    if (totalTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'total' }, totalTokens);
+    }
+}
 
 bot.command('character', async (ctx) => {
     const textParts = ctx.msg.text.split(' ').map((arg) => arg.trim());
@@ -286,6 +326,10 @@ bot.use(limit(
         limit: 1,
 
         onLimitExceeded: async (ctx) => {
+            rateLimitExceededTotal.inc({
+                limiter: 'character_callback',
+                scope: 'chat_or_user',
+            });
             await ctx.answerCallbackQuery(ctx.t('character-rate-limit'));
         },
 
@@ -422,35 +466,67 @@ bot.callbackQuery(/set.*/, async (ctx) => {
             task: 'character',
             expectsStructuredOutput: true,
         });
+        const labels = {
+            task: generationPolicy.telemetry.task,
+            provider: generationPolicy.telemetry.provider,
+            model_ref: generationPolicy.telemetry.modelRef,
+            reply_method: 'character',
+            downgraded: 'false',
+        };
         const providerOptions = generationPolicy
             .providerOptions as Parameters<
                 typeof generateObject
             >[0]['providerOptions'];
-        const result = await generateObject({
-            model: generationPolicy.model,
-            providerOptions,
-            schema: z.array(z.string()),
-            temperature: config.temperature,
-            topK: config.topK,
-            topP: config.topP,
-            maxOutputTokens: generationPolicy.maxOutputTokens,
-            prompt:
-                `Напиши варианты имени "${character.name}", которые пользователи могут использовать в качестве обращения к этому персонажу. ` +
-                'Варианты должны быть на русском, английском, уменьшительно ласкательные и очевидные похожие формы.',
-            experimental_telemetry: {
-                isEnabled: true,
-                functionId: 'character-names',
-                metadata: buildGenerationTelemetryMetadata({
-                    sessionId: chatId.toString(),
-                    userId: '',
-                    tags: ['character'],
-                    temperature: config.temperature,
-                    topK: config.topK,
-                    topP: config.topP,
-                    policy: generationPolicy,
-                }),
-            },
+        aiRequestsTotal.inc(labels);
+        const startedAt = performance.now();
+        let result;
+        try {
+            result = await generateObject({
+                model: generationPolicy.model,
+                providerOptions,
+                schema: z.array(z.string()),
+                temperature: config.temperature,
+                topK: config.topK,
+                topP: config.topP,
+                maxOutputTokens: generationPolicy.maxOutputTokens,
+                prompt:
+                    `Напиши варианты имени "${character.name}", которые пользователи могут использовать в качестве обращения к этому персонажу. ` +
+                    'Варианты должны быть на русском, английском, уменьшительно ласкательные и очевидные похожие формы.',
+                experimental_telemetry: {
+                    isEnabled: true,
+                    functionId: 'character-names',
+                    metadata: buildGenerationTelemetryMetadata({
+                        sessionId: chatId.toString(),
+                        userId: '',
+                        tags: ['character'],
+                        temperature: config.temperature,
+                        topK: config.topK,
+                        topP: config.topP,
+                        policy: generationPolicy,
+                    }),
+                },
+            });
+        } catch (error) {
+            aiFailuresTotal.inc({ ...labels, error_type: errorType(error) });
+            throw error;
+        } finally {
+            aiRequestDurationSeconds.observe(
+                labels,
+                (performance.now() - startedAt) / 1000,
+            );
+        }
+        const finishReasonRaw = Reflect.get(result, 'finishReason');
+        aiFinishReasonTotal.inc({
+            ...labels,
+            finish_reason: typeof finishReasonRaw === 'string'
+                ? finishReasonRaw
+                : 'unknown',
         });
+        observeTokenUsage({
+            task: generationPolicy.telemetry.task,
+            provider: generationPolicy.telemetry.provider,
+            model_ref: generationPolicy.telemetry.modelRef,
+        }, Reflect.get(result, 'usage'));
         names = result.object;
     } catch (error) {
         logger.error(error, 'Error getting names for character');

--- a/lib/telegram/bot/notes.ts
+++ b/lib/telegram/bot/notes.ts
@@ -12,6 +12,45 @@ import {
 import { resolveGenerationPolicy } from '../../ai/generation-policy.ts';
 import { buildGenerationTelemetryMetadata } from '../../ai/telemetry-metadata.ts';
 import { getUsageSnapshot } from '../usage-window.ts';
+import {
+    aiFailuresTotal,
+    aiFinishReasonTotal,
+    aiRequestDurationSeconds,
+    aiRequestsTotal,
+    aiTokensTotal,
+    errorType,
+} from '../../app/metrics.ts';
+
+function tokenCountFromUsage(usage: unknown, key: string): number | undefined {
+    if (typeof usage !== 'object' || usage === null) {
+        return undefined;
+    }
+
+    const raw = Reflect.get(usage, key);
+    return typeof raw === 'number' && Number.isFinite(raw) && raw >= 0
+        ? raw
+        : undefined;
+}
+
+function observeTokenUsage(labels: {
+    task: string;
+    provider: string;
+    model_ref: string;
+}, usage: unknown): void {
+    const inputTokens = tokenCountFromUsage(usage, 'inputTokens');
+    const outputTokens = tokenCountFromUsage(usage, 'outputTokens');
+    const totalTokens = tokenCountFromUsage(usage, 'totalTokens');
+
+    if (inputTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'input' }, inputTokens);
+    }
+    if (outputTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'output' }, outputTokens);
+    }
+    if (totalTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'total' }, totalTokens);
+    }
+}
 
 export default function notes(config: Config, botId: number) {
     const bot = new Composer<SlushaContext>();
@@ -112,35 +151,66 @@ export default function notes(config: Config, botId: number) {
                     task: 'notes',
                     expectsStructuredOutput: false,
                 });
+                const labels = {
+                    task: generationPolicy.telemetry.task,
+                    provider: generationPolicy.telemetry.provider,
+                    model_ref: generationPolicy.telemetry.modelRef,
+                    reply_method: 'notes',
+                    downgraded: usageSnapshot.downgraded ? 'true' : 'false',
+                };
                 const providerOptions = generationPolicy
                     .providerOptions as Parameters<
                         typeof generateText
                     >[0]['providerOptions'];
-                response = await generateText({
-                    model: generationPolicy.model,
-                    providerOptions,
-                    messages,
-                    temperature: effectiveConfig.ai.temperature,
-                    topK: effectiveConfig.ai.topK,
-                    topP: effectiveConfig.ai.topP,
-                    maxOutputTokens: generationPolicy.maxOutputTokens,
-                    experimental_telemetry: {
-                        isEnabled: true,
-                        functionId: 'generate-notes',
-                        metadata: buildGenerationTelemetryMetadata({
-                            sessionId: ctx.chat.id.toString(),
-                            userId: ctx.chat.type === 'private'
-                                ? ctx.from?.id.toString()
-                                : '',
-                            chatName,
-                            tags,
-                            temperature: effectiveConfig.ai.temperature,
-                            topK: effectiveConfig.ai.topK,
-                            topP: effectiveConfig.ai.topP,
-                            policy: generationPolicy,
-                        }),
-                    },
+                aiRequestsTotal.inc(labels);
+                const startedAt = performance.now();
+                try {
+                    response = await generateText({
+                        model: generationPolicy.model,
+                        providerOptions,
+                        messages,
+                        temperature: effectiveConfig.ai.temperature,
+                        topK: effectiveConfig.ai.topK,
+                        topP: effectiveConfig.ai.topP,
+                        maxOutputTokens: generationPolicy.maxOutputTokens,
+                        experimental_telemetry: {
+                            isEnabled: true,
+                            functionId: 'generate-notes',
+                            metadata: buildGenerationTelemetryMetadata({
+                                sessionId: ctx.chat.id.toString(),
+                                userId: ctx.chat.type === 'private'
+                                    ? ctx.from?.id.toString()
+                                    : '',
+                                chatName,
+                                tags,
+                                temperature: effectiveConfig.ai.temperature,
+                                topK: effectiveConfig.ai.topK,
+                                topP: effectiveConfig.ai.topP,
+                                policy: generationPolicy,
+                            }),
+                        },
+                    });
+                } catch (error) {
+                    aiFailuresTotal.inc({
+                        ...labels,
+                        error_type: errorType(error),
+                    });
+                    throw error;
+                } finally {
+                    aiRequestDurationSeconds.observe(
+                        labels,
+                        (performance.now() - startedAt) / 1000,
+                    );
+                }
+                aiFinishReasonTotal.inc({
+                    ...labels,
+                    finish_reason: response.finishReason,
                 });
+                observeTokenUsage({
+                    task: generationPolicy.telemetry.task,
+                    provider: generationPolicy.telemetry.provider,
+                    model_ref: generationPolicy.telemetry.modelRef,
+                }, response.totalUsage);
             } catch (error) {
                 logger.error('Could not get summary: ', error);
                 return;
@@ -328,35 +398,66 @@ export default function notes(config: Config, botId: number) {
                     task: 'memory',
                     expectsStructuredOutput: false,
                 });
+                const labels = {
+                    task: generationPolicy.telemetry.task,
+                    provider: generationPolicy.telemetry.provider,
+                    model_ref: generationPolicy.telemetry.modelRef,
+                    reply_method: 'memory',
+                    downgraded: usageSnapshot.downgraded ? 'true' : 'false',
+                };
                 const providerOptions = generationPolicy
                     .providerOptions as Parameters<
                         typeof generateText
                     >[0]['providerOptions'];
-                response = await generateText({
-                    model: generationPolicy.model,
-                    providerOptions,
-                    messages,
-                    temperature: effectiveConfig.ai.temperature,
-                    topK: effectiveConfig.ai.topK,
-                    topP: effectiveConfig.ai.topP,
-                    maxOutputTokens: generationPolicy.maxOutputTokens,
-                    experimental_telemetry: {
-                        isEnabled: true,
-                        functionId: 'generate-memory',
-                        metadata: buildGenerationTelemetryMetadata({
-                            sessionId: ctx.chat.id.toString(),
-                            userId: ctx.chat.type === 'private'
-                                ? ctx.from?.id.toString()
-                                : '',
-                            chatName,
-                            tags,
-                            temperature: effectiveConfig.ai.temperature,
-                            topK: effectiveConfig.ai.topK,
-                            topP: effectiveConfig.ai.topP,
-                            policy: generationPolicy,
-                        }),
-                    },
+                aiRequestsTotal.inc(labels);
+                const startedAt = performance.now();
+                try {
+                    response = await generateText({
+                        model: generationPolicy.model,
+                        providerOptions,
+                        messages,
+                        temperature: effectiveConfig.ai.temperature,
+                        topK: effectiveConfig.ai.topK,
+                        topP: effectiveConfig.ai.topP,
+                        maxOutputTokens: generationPolicy.maxOutputTokens,
+                        experimental_telemetry: {
+                            isEnabled: true,
+                            functionId: 'generate-memory',
+                            metadata: buildGenerationTelemetryMetadata({
+                                sessionId: ctx.chat.id.toString(),
+                                userId: ctx.chat.type === 'private'
+                                    ? ctx.from?.id.toString()
+                                    : '',
+                                chatName,
+                                tags,
+                                temperature: effectiveConfig.ai.temperature,
+                                topK: effectiveConfig.ai.topK,
+                                topP: effectiveConfig.ai.topP,
+                                policy: generationPolicy,
+                            }),
+                        },
+                    });
+                } catch (error) {
+                    aiFailuresTotal.inc({
+                        ...labels,
+                        error_type: errorType(error),
+                    });
+                    throw error;
+                } finally {
+                    aiRequestDurationSeconds.observe(
+                        labels,
+                        (performance.now() - startedAt) / 1000,
+                    );
+                }
+                aiFinishReasonTotal.inc({
+                    ...labels,
+                    finish_reason: response.finishReason,
                 });
+                observeTokenUsage({
+                    task: generationPolicy.telemetry.task,
+                    provider: generationPolicy.telemetry.provider,
+                    model_ref: generationPolicy.telemetry.modelRef,
+                }, response.totalUsage);
             } catch (error) {
                 logger.error('Could not get memory: ', error);
                 return;

--- a/lib/telegram/handlers/ai.ts
+++ b/lib/telegram/handlers/ai.ts
@@ -620,6 +620,7 @@ export default function registerAI(bot: Bot<SlushaContext>) {
 
         const isComments = isTelegramCommentsHistory(savedHistory);
         const currentLocale = chatState.locale ??
+            ctx.from?.language_code ??
             await ctx.i18n.getLocale();
         const character = chatState.character;
 

--- a/lib/telegram/handlers/ai.ts
+++ b/lib/telegram/handlers/ai.ts
@@ -47,6 +47,14 @@ import {
     getUsageSnapshot,
     recordUsageEvent,
 } from '../usage-window.ts';
+import {
+    aiFailuresTotal,
+    aiFinishReasonTotal,
+    aiRequestDurationSeconds,
+    aiRequestsTotal,
+    aiTokensTotal,
+    errorType,
+} from '../../app/metrics.ts';
 
 const DEFAULT_CHAT_ACTIONS_TOOL_DESCRIPTION =
     'Submit Telegram actions once per turn. Return entries where each item is either {"type":"reply","text":"...","target_ref":"tN"} or {"type":"react","react":"❤","target_ref":"tN"}. Use target_ref values from Reply Target Map. If target_ref is omitted, action applies to the triggering message.';
@@ -309,6 +317,37 @@ function buildTelemetryMetadata(
     });
 }
 
+function tokenCountFromUsage(usage: unknown, key: string): number | undefined {
+    if (typeof usage !== 'object' || usage === null) {
+        return undefined;
+    }
+
+    const raw = Reflect.get(usage, key);
+    return typeof raw === 'number' && Number.isFinite(raw) && raw >= 0
+        ? raw
+        : undefined;
+}
+
+function observeTokenUsage(labels: {
+    task: string;
+    provider: string;
+    model_ref: string;
+}, usage: unknown): void {
+    const inputTokens = tokenCountFromUsage(usage, 'inputTokens');
+    const outputTokens = tokenCountFromUsage(usage, 'outputTokens');
+    const totalTokens = tokenCountFromUsage(usage, 'totalTokens');
+
+    if (inputTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'input' }, inputTokens);
+    }
+    if (outputTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'output' }, outputTokens);
+    }
+    if (totalTokens !== undefined) {
+        aiTokensTotal.inc({ ...labels, token_type: 'total' }, totalTokens);
+    }
+}
+
 type EffectiveConfig = Awaited<
     ReturnType<SlushaContext['m']['getEffectiveConfig']>
 >;
@@ -320,7 +359,10 @@ async function sendGeneratedOutput(params: {
     targetRefMap: Map<string, number>;
     enabledReactions: string[];
     effectiveConfig: EffectiveConfig;
-    historyById: Map<number, Awaited<ReturnType<SlushaContext['m']['getHistory']>>[number]>;
+    historyById: Map<
+        number,
+        Awaited<ReturnType<SlushaContext['m']['getHistory']>>[number]
+    >;
 }): Promise<boolean> {
     const {
         bot,
@@ -592,7 +634,10 @@ export default function registerAI(bot: Bot<SlushaContext>) {
             ? Math.min(baseMessagesToPass, usageConfig.downgradeMessagesToPass)
             : baseMessagesToPass;
         const bytesLimit = isDowngraded && usageConfig.disableLongContext
-            ? Math.min(effectiveConfig.ai.bytesLimit, usageConfig.downgradeBytesLimit)
+            ? Math.min(
+                effectiveConfig.ai.bytesLimit,
+                usageConfig.downgradeBytesLimit,
+            )
             : effectiveConfig.ai.bytesLimit;
         const maxTargetCount = Math.min(
             Math.max(messagesToPass * 2, 12),
@@ -794,32 +839,67 @@ export default function registerAI(bot: Bot<SlushaContext>) {
                 .providerOptions as Parameters<
                     typeof generateText
                 >[0]['providerOptions'];
-            const response = await generateText({
-                model: generationPolicy.model,
-                providerOptions,
-                maxRetries: maxGenerationRetries,
-                tools: enabledReactions.length > 0
-                    ? {
-                        send_chat_reactions: sendChatReactionsTool,
-                    }
-                    : undefined,
-                messages,
-                temperature: effectiveConfig.ai.temperature,
-                topK: effectiveConfig.ai.topK,
-                topP: effectiveConfig.ai.topP,
-                maxOutputTokens: generationPolicy.maxOutputTokens,
-                experimental_telemetry: {
-                    isEnabled: true,
-                    functionId: 'user-message-dumb',
-                    metadata: buildTelemetryMetadata(
-                        ctx,
-                        chatName,
-                        tags,
-                        effectiveConfig,
-                        generationPolicy,
-                    ),
-                },
+            const labels = {
+                task: generationPolicy.telemetry.task,
+                provider: generationPolicy.telemetry.provider,
+                model_ref: generationPolicy.telemetry.modelRef,
+                reply_method: replyMethod,
+                downgraded: isDowngraded ? 'true' : 'false',
+            };
+            const tokenLabels = {
+                task: generationPolicy.telemetry.task,
+                provider: generationPolicy.telemetry.provider,
+                model_ref: generationPolicy.telemetry.modelRef,
+            };
+            aiRequestsTotal.inc(labels);
+            const startedAt = performance.now();
+
+            let response;
+            try {
+                response = await generateText({
+                    model: generationPolicy.model,
+                    providerOptions,
+                    maxRetries: maxGenerationRetries,
+                    tools: enabledReactions.length > 0
+                        ? {
+                            send_chat_reactions: sendChatReactionsTool,
+                        }
+                        : undefined,
+                    messages,
+                    temperature: effectiveConfig.ai.temperature,
+                    topK: effectiveConfig.ai.topK,
+                    topP: effectiveConfig.ai.topP,
+                    maxOutputTokens: generationPolicy.maxOutputTokens,
+                    experimental_telemetry: {
+                        isEnabled: true,
+                        functionId: 'user-message-dumb',
+                        metadata: buildTelemetryMetadata(
+                            ctx,
+                            chatName,
+                            tags,
+                            effectiveConfig,
+                            generationPolicy,
+                        ),
+                    },
+                });
+            } catch (error) {
+                aiFailuresTotal.inc({
+                    ...labels,
+                    error_type: errorType(error),
+                });
+                throw error;
+            } finally {
+                aiRequestDurationSeconds.observe(
+                    labels,
+                    (performance.now() - startedAt) / 1000,
+                );
+            }
+
+            aiFinishReasonTotal.inc({
+                ...labels,
+                finish_reason: response.finishReason,
             });
+            observeTokenUsage(tokenLabels, response.totalUsage);
 
             const plainTextResponse = response.text.trim();
             const replyEntries = parsePlainTextRepliesWithTargets(
@@ -857,35 +937,70 @@ export default function registerAI(bot: Bot<SlushaContext>) {
                 .providerOptions as Parameters<
                     typeof generateText
                 >[0]['providerOptions'];
-            const result = await generateText({
-                model: generationPolicy.model,
-                providerOptions,
-                maxRetries: maxGenerationRetries,
-                tools: {
-                    send_chat_actions: sendChatActionsTool,
-                },
-                toolChoice: {
-                    type: 'tool',
-                    toolName: 'send_chat_actions',
-                },
-                stopWhen: hasToolCall('send_chat_actions'),
-                temperature: effectiveConfig.ai.temperature,
-                topK: effectiveConfig.ai.topK,
-                topP: effectiveConfig.ai.topP,
-                maxOutputTokens: generationPolicy.maxOutputTokens,
-                messages,
-                experimental_telemetry: {
-                    isEnabled: true,
-                    functionId: 'user-message',
-                    metadata: buildTelemetryMetadata(
-                        ctx,
-                        chatName,
-                        tags,
-                        effectiveConfig,
-                        generationPolicy,
-                    ),
-                },
+            const labels = {
+                task: generationPolicy.telemetry.task,
+                provider: generationPolicy.telemetry.provider,
+                model_ref: generationPolicy.telemetry.modelRef,
+                reply_method: replyMethod,
+                downgraded: isDowngraded ? 'true' : 'false',
+            };
+            const tokenLabels = {
+                task: generationPolicy.telemetry.task,
+                provider: generationPolicy.telemetry.provider,
+                model_ref: generationPolicy.telemetry.modelRef,
+            };
+            aiRequestsTotal.inc(labels);
+            const startedAt = performance.now();
+
+            let result;
+            try {
+                result = await generateText({
+                    model: generationPolicy.model,
+                    providerOptions,
+                    maxRetries: maxGenerationRetries,
+                    tools: {
+                        send_chat_actions: sendChatActionsTool,
+                    },
+                    toolChoice: {
+                        type: 'tool',
+                        toolName: 'send_chat_actions',
+                    },
+                    stopWhen: hasToolCall('send_chat_actions'),
+                    temperature: effectiveConfig.ai.temperature,
+                    topK: effectiveConfig.ai.topK,
+                    topP: effectiveConfig.ai.topP,
+                    maxOutputTokens: generationPolicy.maxOutputTokens,
+                    messages,
+                    experimental_telemetry: {
+                        isEnabled: true,
+                        functionId: 'user-message',
+                        metadata: buildTelemetryMetadata(
+                            ctx,
+                            chatName,
+                            tags,
+                            effectiveConfig,
+                            generationPolicy,
+                        ),
+                    },
+                });
+            } catch (error) {
+                aiFailuresTotal.inc({
+                    ...labels,
+                    error_type: errorType(error),
+                });
+                throw error;
+            } finally {
+                aiRequestDurationSeconds.observe(
+                    labels,
+                    (performance.now() - startedAt) / 1000,
+                );
+            }
+
+            aiFinishReasonTotal.inc({
+                ...labels,
+                finish_reason: result.finishReason,
             });
+            observeTokenUsage(tokenLabels, result.totalUsage);
 
             const entries = parseSendChatActionsEntries(result.toolCalls);
             if (entries) {

--- a/lib/telegram/middlewares/rate-limit.ts
+++ b/lib/telegram/middlewares/rate-limit.ts
@@ -1,4 +1,5 @@
 import { limit } from 'grammy_ratelimiter';
+import { rateLimitExceededTotal } from '../../app/metrics.ts';
 
 type RedisClient = {
     incr(key: string): Promise<number>;
@@ -16,7 +17,10 @@ export function shortBurstLimiter() {
         timeFrame: 2000,
         limit: 1,
         onLimitExceeded: () => {
-            // no-op
+            rateLimitExceededTotal.inc({
+                limiter: 'short_burst',
+                scope: 'chat_or_user',
+            });
         },
         keyGenerator: (ctx) => {
             if (ctx.chat?.type === 'group' || ctx.chat?.type === 'supergroup') {
@@ -32,6 +36,10 @@ export function rollingLimiter() {
         timeFrame: 1 * 60 * 1000,
         limit: 20,
         onLimitExceeded: (ctx) => {
+            rateLimitExceededTotal.inc({
+                limiter: 'rolling',
+                scope: 'chat_or_user',
+            });
             if (ctx.chat?.id && ctx.reply) {
                 return ctx.reply('Рейтлимитим тебя');
             }

--- a/lib/telegram/setup-bot.ts
+++ b/lib/telegram/setup-bot.ts
@@ -12,6 +12,11 @@ import {
 import { sequentialize } from '@grammyjs/runner';
 import { canMemberSendTextMessages } from './reply-rights.ts';
 import { Message } from 'grammy_types';
+import {
+    errorType,
+    telegramHandlerErrorsTotal,
+    telegramUpdatesTotal,
+} from '../app/metrics.ts';
 
 interface RequestInfo {
     isRandom: boolean;
@@ -131,6 +136,40 @@ function isSameTopic(left: Message, right: Message): boolean {
     return leftTopic === rightTopic;
 }
 
+function resolveUpdateType(update: unknown): string {
+    if (typeof update !== 'object' || update === null) {
+        return 'unknown';
+    }
+
+    const record = update as Record<string, unknown>;
+    const knownTypes = [
+        'message',
+        'edited_message',
+        'channel_post',
+        'edited_channel_post',
+        'inline_query',
+        'chosen_inline_result',
+        'callback_query',
+        'shipping_query',
+        'pre_checkout_query',
+        'poll',
+        'poll_answer',
+        'my_chat_member',
+        'chat_member',
+        'chat_join_request',
+        'message_reaction',
+        'message_reaction_count',
+    ];
+
+    for (const type of knownTypes) {
+        if (record[type] !== undefined) {
+            return type;
+        }
+    }
+
+    return 'unknown';
+}
+
 async function resolveThreadForIncomingMessage(
     memory: ChatMemory,
     incoming: Message,
@@ -205,12 +244,24 @@ export default async function setupBot(config: Config, memory: Memory) {
 
     const bot = new Bot<SlushaContext>(config.botToken);
 
-    bot.catch((error) =>
+    bot.catch((error) => {
+        const updateType = resolveUpdateType(error.ctx?.update);
+        telegramHandlerErrorsTotal.inc({
+            update_type: updateType,
+            error_type: errorType(error.error),
+        });
         logger.error({
             ...error,
             ctx: { ...error.ctx, m: undefined, memory: undefined },
-        })
-    );
+        });
+    });
+
+    bot.use(async (ctx, next) => {
+        telegramUpdatesTotal.inc({
+            update_type: resolveUpdateType(ctx.update),
+        });
+        await next();
+    });
 
     // Make sure messages are handled sequentially
     bot.use(sequentialize((ctx) => {

--- a/lib/telegram/usage-window.ts
+++ b/lib/telegram/usage-window.ts
@@ -2,6 +2,11 @@ import { and, eq, gte, lt, sql } from 'drizzle-orm';
 import { ChatConfigOverride, UserConfig } from '../config.ts';
 import { DbClient } from '../db/client.ts';
 import { requestWindowEvents } from '../db/schema.ts';
+import {
+    usageCleanupRunsTotal,
+    usageDowngradedTotal,
+    usageEventsRecordedTotal,
+} from '../app/metrics.ts';
 
 export type UsageTier = 'free' | 'trusted';
 
@@ -48,7 +53,10 @@ function mergeLimit(
     };
 }
 
-export function resolveUsageTier(config: UserConfig, userId?: number): UsageTier {
+export function resolveUsageTier(
+    config: UserConfig,
+    userId?: number,
+): UsageTier {
     if (userId && config.trustedIds.includes(userId)) {
         return 'trusted';
     }
@@ -85,6 +93,7 @@ export async function cleanupUsageEvents(
     await db.delete(requestWindowEvents).where(
         lt(requestWindowEvents.createdAt, cutoff),
     );
+    usageCleanupRunsTotal.inc();
 }
 
 export async function recordUsageEvent(
@@ -95,6 +104,9 @@ export async function recordUsageEvent(
         chatId: input.chatId,
         userId: input.userId,
         createdAt: input.now ?? Date.now(),
+    });
+    usageEventsRecordedTotal.inc({
+        has_user_id: input.userId ? 'true' : 'false',
     });
 }
 
@@ -111,7 +123,11 @@ export async function getUsageSnapshot(
     const now = input.now ?? Date.now();
     const tier = resolveUsageTier(input.config, input.userId);
     const userLimit = resolvePerUserLimit(input.config, tier);
-    const chatLimit = resolvePerChatLimit(input.config, tier, input.chatOverride);
+    const chatLimit = resolvePerChatLimit(
+        input.config,
+        tier,
+        input.chatOverride,
+    );
 
     const userWindowStart = now - userLimit.windowMinutes * 60 * 1000;
     const chatWindowStart = now - chatLimit.windowMinutes * 60 * 1000;
@@ -149,6 +165,13 @@ export async function getUsageSnapshot(
         : chatExceeded
         ? 'chat'
         : 'none';
+
+    if (downgradeReason !== 'none') {
+        usageDowngradedTotal.inc({
+            tier,
+            reason: downgradeReason,
+        });
+    }
 
     return {
         tier,

--- a/lib/web/server.ts
+++ b/lib/web/server.ts
@@ -30,7 +30,16 @@ import logger from '../logger.ts';
 import { type BotCharacter, ChatMemory, Memory } from '../memory.ts';
 import { chatMembers, chats } from '../db/schema.ts';
 import { ALLOWED_REACTIONS } from '../telegram/reactions.ts';
-import { getUsageSnapshot, renderProgressBar } from '../telegram/usage-window.ts';
+import {
+    getUsageSnapshot,
+    renderProgressBar,
+} from '../telegram/usage-window.ts';
+import {
+    httpRequestDurationSeconds,
+    httpRequestsTotal,
+    renderPrometheusMetrics,
+    statusClass,
+} from '../app/metrics.ts';
 
 interface RuntimeConfigAccess {
     getBotToken: () => string;
@@ -283,302 +292,404 @@ async function serveWidgetAsset(
     }
 }
 
+function resolveRouteTemplate(pathname: string): string {
+    if (pathname.startsWith('/widget')) return '/widget/*';
+    if (pathname === '/healthz') return '/healthz';
+    if (pathname === '/metrics') return '/metrics';
+    if (pathname === '/api/config/bootstrap') return '/api/config/bootstrap';
+    if (pathname === '/api/config/global') return '/api/config/global';
+    if (/^\/api\/config\/chat\/-?\d+\/internals$/.test(pathname)) {
+        return '/api/config/chat/:chatId/internals';
+    }
+    if (/^\/api\/config\/chat\/-?\d+$/.test(pathname)) {
+        return '/api/config/chat/:chatId';
+    }
+    if (pathname.startsWith('/api/config/')) return '/api/config/*';
+    return 'not_found';
+}
+
 export function startWebServer(options: StartWebServerOptions) {
     const port = Number(Deno.env.get('WEB_PORT') ?? '8080');
     const hostname = Deno.env.get('WEB_HOST') ?? '0.0.0.0';
 
     const server = Deno.serve({ port, hostname }, async (req) => {
+        const startedAt = performance.now();
         const url = new URL(req.url);
+        const routeTemplate = resolveRouteTemplate(url.pathname);
 
-        if (req.method === 'GET') {
-            const staticResponse = await serveWidgetAsset(url.pathname);
-            if (staticResponse) return staticResponse;
-        }
-
-        if (url.pathname === '/healthz') {
-            return new Response('ok');
-        }
-
-        if (!url.pathname.startsWith('/api/config/')) {
-            return new Response('Not found', { status: 404 });
-        }
-
+        let response: Response;
         try {
-            const initData = pickInitData(req);
-            const verified = await verifyTelegramInitData(
-                initData,
-                options.runtimeConfig.getBotToken(),
-            );
-            const userId = verified.user?.id;
-            const globalConfig = await getGlobalUserConfig(options.memory.db);
-            const role = resolveConfigRole(globalConfig, userId);
+            response = await (async () => {
+                if (req.method === 'GET') {
+                    const staticResponse = await serveWidgetAsset(url.pathname);
+                    if (staticResponse) return staticResponse;
+                }
 
-            if (
-                url.pathname === '/api/config/bootstrap' && req.method === 'GET'
-            ) {
-                const chatIdRaw = url.searchParams.get('chatId');
-                const chatId = chatIdRaw ? Number(chatIdRaw) : undefined;
+                if (url.pathname === '/healthz') {
+                    return new Response('ok');
+                }
 
-                const canEditGlobal = canEditGlobalConfig(
-                    globalConfig,
-                    userId,
-                );
-                const canViewGlobal = canEditGlobal;
-                const availableChats = userId
-                    ? await resolveAvailableChats(
-                        options,
-                        userId,
-                        canEditGlobal,
-                    )
-                    : [];
-                const serializedGlobalConfig = JSON.parse(
-                    serializeUserConfig(globalConfig),
-                ) as UserConfig;
-                const globalPayload = projectGlobalConfigForRole(
-                    serializedGlobalConfig,
-                    role,
-                );
+                if (url.pathname === '/metrics') {
+                    return new Response(renderPrometheusMetrics(), {
+                        status: 200,
+                        headers: {
+                            'content-type':
+                                'text/plain; version=0.0.4; charset=utf-8',
+                            'cache-control': 'no-store',
+                        },
+                    });
+                }
 
-                let chatOverridePayload: unknown = undefined;
-                let effectiveConfigPayload: unknown = undefined;
-                let currentCharacter: unknown = undefined;
-                let canEditChat = false;
-                let canEditChatInternals = false;
-                let chatInternalsPayload: ChatInternalsPayload | undefined;
-                let usageWindowStatus: UsageWindowStatusPayload | undefined;
+                if (!url.pathname.startsWith('/api/config/')) {
+                    return new Response('Not found', { status: 404 });
+                }
 
-                if (chatId !== undefined && Number.isFinite(chatId)) {
-                    canEditChat = await canEditChatConfig(
-                        options.bot,
-                        globalConfig,
-                        chatId,
-                        userId,
+                try {
+                    const initData = pickInitData(req);
+                    const verified = await verifyTelegramInitData(
+                        initData,
+                        options.runtimeConfig.getBotToken(),
                     );
-                    if (canEditChat) {
-                        const chat = await options.bot.api.getChat(chatId);
-                        const chatMemory = new ChatMemory(options.memory, chat);
-                        const currentChat = await chatMemory.getChat();
-                        canEditChatInternals = role === 'admin';
-                        currentCharacter = projectCurrentCharacter(
-                            currentChat.character,
-                        );
-                        if (canEditChatInternals) {
-                            chatInternalsPayload = {
-                                summary: notesToSummary(currentChat.notes),
-                                personalNotes: currentChat.memory ?? '',
-                            };
-                        }
-                        const chatOverride = await chatMemory
-                            .getChatConfigOverride();
-                        chatOverridePayload = chatOverride
-                            ? JSON.parse(
-                                serializeChatOverride(
-                                    sanitizeChatOverrideForRole(
-                                        chatOverride,
-                                        role,
-                                        globalConfig,
-                                        false,
-                                    ),
-                                ),
-                            )
-                            : {};
+                    const userId = verified.user?.id;
+                    const globalConfig = await getGlobalUserConfig(
+                        options.memory.db,
+                    );
+                    const role = resolveConfigRole(globalConfig, userId);
 
-                        const effectiveConfig = mergeWithChatOverride(
+                    if (
+                        url.pathname === '/api/config/bootstrap' &&
+                        req.method === 'GET'
+                    ) {
+                        const chatIdRaw = url.searchParams.get('chatId');
+                        const chatId = chatIdRaw
+                            ? Number(chatIdRaw)
+                            : undefined;
+
+                        const canEditGlobal = canEditGlobalConfig(
                             globalConfig,
-                            chatOverride,
+                            userId,
                         );
-                        const serializedEffectiveConfig = JSON.parse(
-                            serializeUserConfig(effectiveConfig),
+                        const canViewGlobal = canEditGlobal;
+                        const availableChats = userId
+                            ? await resolveAvailableChats(
+                                options,
+                                userId,
+                                canEditGlobal,
+                            )
+                            : [];
+                        const serializedGlobalConfig = JSON.parse(
+                            serializeUserConfig(globalConfig),
                         ) as UserConfig;
-                        effectiveConfigPayload = projectEffectiveConfigForRole(
-                            serializedEffectiveConfig,
+                        const globalPayload = projectGlobalConfigForRole(
+                            serializedGlobalConfig,
                             role,
                         );
 
-                        if (userId) {
-                            const usageSnapshot = await getUsageSnapshot(
-                                options.memory.db,
-                                {
-                                    config: globalConfig,
-                                    chatId,
-                                    userId,
-                                    chatOverride,
-                                },
+                        let chatOverridePayload: unknown = undefined;
+                        let effectiveConfigPayload: unknown = undefined;
+                        let currentCharacter: unknown = undefined;
+                        let canEditChat = false;
+                        let canEditChatInternals = false;
+                        let chatInternalsPayload:
+                            | ChatInternalsPayload
+                            | undefined;
+                        let usageWindowStatus:
+                            | UsageWindowStatusPayload
+                            | undefined;
+
+                        if (chatId !== undefined && Number.isFinite(chatId)) {
+                            canEditChat = await canEditChatConfig(
+                                options.bot,
+                                globalConfig,
+                                chatId,
+                                userId,
                             );
-                            usageWindowStatus = {
-                                tier: usageSnapshot.tier,
-                                downgraded: usageSnapshot.downgraded,
-                                userUsed: usageSnapshot.user.used,
-                                userMax: usageSnapshot.user.maxRequests,
-                                userWindowMinutes:
-                                    usageSnapshot.user.windowMinutes,
-                                userBar: renderProgressBar(
-                                    usageSnapshot.user.used,
-                                    usageSnapshot.user.maxRequests,
-                                    16,
-                                ),
-                                chatUsed: usageSnapshot.chat.used,
-                                chatMax: usageSnapshot.chat.maxRequests,
-                                chatWindowMinutes:
-                                    usageSnapshot.chat.windowMinutes,
-                                chatBar: renderProgressBar(
-                                    usageSnapshot.chat.used,
-                                    usageSnapshot.chat.maxRequests,
-                                    16,
-                                ),
-                            };
+                            if (canEditChat) {
+                                const chat = await options.bot.api.getChat(
+                                    chatId,
+                                );
+                                const chatMemory = new ChatMemory(
+                                    options.memory,
+                                    chat,
+                                );
+                                const currentChat = await chatMemory.getChat();
+                                canEditChatInternals = role === 'admin';
+                                currentCharacter = projectCurrentCharacter(
+                                    currentChat.character,
+                                );
+                                if (canEditChatInternals) {
+                                    chatInternalsPayload = {
+                                        summary: notesToSummary(
+                                            currentChat.notes,
+                                        ),
+                                        personalNotes: currentChat.memory ?? '',
+                                    };
+                                }
+                                const chatOverride = await chatMemory
+                                    .getChatConfigOverride();
+                                chatOverridePayload = chatOverride
+                                    ? JSON.parse(
+                                        serializeChatOverride(
+                                            sanitizeChatOverrideForRole(
+                                                chatOverride,
+                                                role,
+                                                globalConfig,
+                                                false,
+                                            ),
+                                        ),
+                                    )
+                                    : {};
+
+                                const effectiveConfig = mergeWithChatOverride(
+                                    globalConfig,
+                                    chatOverride,
+                                );
+                                const serializedEffectiveConfig = JSON.parse(
+                                    serializeUserConfig(effectiveConfig),
+                                ) as UserConfig;
+                                effectiveConfigPayload =
+                                    projectEffectiveConfigForRole(
+                                        serializedEffectiveConfig,
+                                        role,
+                                    );
+
+                                if (userId) {
+                                    const usageSnapshot =
+                                        await getUsageSnapshot(
+                                            options.memory.db,
+                                            {
+                                                config: globalConfig,
+                                                chatId,
+                                                userId,
+                                                chatOverride,
+                                            },
+                                        );
+                                    usageWindowStatus = {
+                                        tier: usageSnapshot.tier,
+                                        downgraded: usageSnapshot.downgraded,
+                                        userUsed: usageSnapshot.user.used,
+                                        userMax: usageSnapshot.user.maxRequests,
+                                        userWindowMinutes:
+                                            usageSnapshot.user.windowMinutes,
+                                        userBar: renderProgressBar(
+                                            usageSnapshot.user.used,
+                                            usageSnapshot.user.maxRequests,
+                                            16,
+                                        ),
+                                        chatUsed: usageSnapshot.chat.used,
+                                        chatMax: usageSnapshot.chat.maxRequests,
+                                        chatWindowMinutes:
+                                            usageSnapshot.chat.windowMinutes,
+                                        chatBar: renderProgressBar(
+                                            usageSnapshot.chat.used,
+                                            usageSnapshot.chat.maxRequests,
+                                            16,
+                                        ),
+                                    };
+                                }
+                            }
                         }
+
+                        const capabilities = buildBootstrapCapabilities(role);
+
+                        return jsonResponse({
+                            role: capabilities.role,
+                            categories: capabilities.categories,
+                            availableModels: getModelOptionsForRole(
+                                globalConfig,
+                                role,
+                            ),
+                            availableReactions: [...ALLOWED_REACTIONS],
+                            canViewGlobal,
+                            canEditGlobal,
+                            canEditChat,
+                            canEditChatInternals,
+                            availableChats,
+                            globalPayload,
+                            chatOverridePayload,
+                            effectiveConfigPayload,
+                            currentCharacter,
+                            chatInternalsPayload,
+                            usageWindowStatus,
+                        });
                     }
+
+                    if (
+                        /^\/api\/config\/chat\/-?\d+\/internals$/.test(
+                            url.pathname,
+                        ) &&
+                        req.method === 'PUT'
+                    ) {
+                        const match =
+                            /^\/api\/config\/chat\/(-?\d+)\/internals$/
+                                .exec(url.pathname);
+                        const chatId = Number(match?.[1]);
+                        if (!Number.isFinite(chatId)) {
+                            return jsonResponse(
+                                { error: 'Invalid chat id' },
+                                400,
+                            );
+                        }
+
+                        const allowed = await canEditChatConfig(
+                            options.bot,
+                            globalConfig,
+                            chatId,
+                            userId,
+                        );
+                        if (!allowed) {
+                            return jsonResponse({ error: 'Forbidden' }, 403);
+                        }
+
+                        if (role !== 'admin') {
+                            return jsonResponse({ error: 'Forbidden' }, 403);
+                        }
+
+                        const body = await req.json() as {
+                            payload?: {
+                                summary?: unknown;
+                                personalNotes?: unknown;
+                            };
+                        };
+                        if (!body.payload || typeof body.payload !== 'object') {
+                            return jsonResponse(
+                                { error: 'Missing payload' },
+                                400,
+                            );
+                        }
+
+                        const summary = typeof body.payload.summary === 'string'
+                            ? body.payload.summary
+                            : '';
+                        const personalNotes =
+                            typeof body.payload.personalNotes === 'string'
+                                ? body.payload.personalNotes
+                                : '';
+
+                        const chatMemory = new ChatMemory(
+                            options.memory,
+                            await options.bot.api.getChat(chatId),
+                        );
+                        await chatMemory.setNotes(summaryToNotes(summary));
+                        await chatMemory.setMemory(
+                            personalNotes.trim().length > 0
+                                ? personalNotes
+                                : undefined,
+                        );
+
+                        return jsonResponse({ ok: true });
+                    }
+
+                    if (
+                        url.pathname === '/api/config/global' &&
+                        req.method === 'PUT'
+                    ) {
+                        if (!canEditGlobalConfig(globalConfig, userId)) {
+                            return jsonResponse({ error: 'Forbidden' }, 403);
+                        }
+
+                        const body = await req.json() as { payload?: unknown };
+                        if (!body.payload) {
+                            return jsonResponse(
+                                { error: 'Missing payload' },
+                                400,
+                            );
+                        }
+
+                        const parsed = parseUserConfigPayload(
+                            JSON.stringify(body.payload),
+                        );
+                        await setGlobalUserConfig(
+                            parsed,
+                            userId,
+                            options.memory.db,
+                        );
+
+                        return jsonResponse({ ok: true });
+                    }
+
+                    if (
+                        url.pathname.startsWith('/api/config/chat/') &&
+                        req.method === 'PUT'
+                    ) {
+                        const chatIdRaw = url.pathname.replace(
+                            '/api/config/chat/',
+                            '',
+                        );
+                        const chatId = Number(chatIdRaw);
+                        if (!Number.isFinite(chatId)) {
+                            return jsonResponse(
+                                { error: 'Invalid chat id' },
+                                400,
+                            );
+                        }
+
+                        const allowed = await canEditChatConfig(
+                            options.bot,
+                            globalConfig,
+                            chatId,
+                            userId,
+                        );
+                        if (!allowed) {
+                            return jsonResponse({ error: 'Forbidden' }, 403);
+                        }
+
+                        const body = await req.json() as { payload?: unknown };
+                        if (!body.payload) {
+                            return jsonResponse(
+                                { error: 'Missing payload' },
+                                400,
+                            );
+                        }
+
+                        const parsedOverride = parseChatOverridePayload(
+                            JSON.stringify(body.payload),
+                        );
+                        const sanitizedOverride = sanitizeChatOverrideForRole(
+                            parsedOverride,
+                            role,
+                            globalConfig,
+                        );
+                        const chatMemory = new ChatMemory(
+                            options.memory,
+                            await options.bot.api.getChat(chatId),
+                        );
+                        await chatMemory.setChatConfigOverride(
+                            sanitizedOverride,
+                            userId,
+                        );
+
+                        return jsonResponse({ ok: true });
+                    }
+
+                    return new Response('Not found', { status: 404 });
+                } catch (error) {
+                    logger.error('Web API error: ', error);
+                    const message = error instanceof Error
+                        ? error.message
+                        : 'Unknown error';
+                    return jsonResponse({ error: message }, 400);
                 }
-
-                const capabilities = buildBootstrapCapabilities(role);
-
-                return jsonResponse({
-                    role: capabilities.role,
-                    categories: capabilities.categories,
-                    availableModels: getModelOptionsForRole(globalConfig, role),
-                    availableReactions: [...ALLOWED_REACTIONS],
-                    canViewGlobal,
-                    canEditGlobal,
-                    canEditChat,
-                    canEditChatInternals,
-                    availableChats,
-                    globalPayload,
-                    chatOverridePayload,
-                    effectiveConfigPayload,
-                    currentCharacter,
-                    chatInternalsPayload,
-                    usageWindowStatus,
-                });
-            }
-
-            if (
-                /^\/api\/config\/chat\/-?\d+\/internals$/.test(url.pathname) &&
-                req.method === 'PUT'
-            ) {
-                const match = /^\/api\/config\/chat\/(-?\d+)\/internals$/
-                    .exec(url.pathname);
-                const chatId = Number(match?.[1]);
-                if (!Number.isFinite(chatId)) {
-                    return jsonResponse({ error: 'Invalid chat id' }, 400);
-                }
-
-                const allowed = await canEditChatConfig(
-                    options.bot,
-                    globalConfig,
-                    chatId,
-                    userId,
-                );
-                if (!allowed) {
-                    return jsonResponse({ error: 'Forbidden' }, 403);
-                }
-
-                if (role !== 'admin') {
-                    return jsonResponse({ error: 'Forbidden' }, 403);
-                }
-
-                const body = await req.json() as {
-                    payload?: { summary?: unknown; personalNotes?: unknown };
-                };
-                if (!body.payload || typeof body.payload !== 'object') {
-                    return jsonResponse({ error: 'Missing payload' }, 400);
-                }
-
-                const summary = typeof body.payload.summary === 'string'
-                    ? body.payload.summary
-                    : '';
-                const personalNotes =
-                    typeof body.payload.personalNotes === 'string'
-                        ? body.payload.personalNotes
-                        : '';
-
-                const chatMemory = new ChatMemory(
-                    options.memory,
-                    await options.bot.api.getChat(chatId),
-                );
-                await chatMemory.setNotes(summaryToNotes(summary));
-                await chatMemory.setMemory(
-                    personalNotes.trim().length > 0 ? personalNotes : undefined,
-                );
-
-                return jsonResponse({ ok: true });
-            }
-
-            if (url.pathname === '/api/config/global' && req.method === 'PUT') {
-                if (!canEditGlobalConfig(globalConfig, userId)) {
-                    return jsonResponse({ error: 'Forbidden' }, 403);
-                }
-
-                const body = await req.json() as { payload?: unknown };
-                if (!body.payload) {
-                    return jsonResponse({ error: 'Missing payload' }, 400);
-                }
-
-                const parsed = parseUserConfigPayload(
-                    JSON.stringify(body.payload),
-                );
-                await setGlobalUserConfig(
-                    parsed,
-                    userId,
-                    options.memory.db,
-                );
-
-                return jsonResponse({ ok: true });
-            }
-
-            if (
-                url.pathname.startsWith('/api/config/chat/') &&
-                req.method === 'PUT'
-            ) {
-                const chatIdRaw = url.pathname.replace('/api/config/chat/', '');
-                const chatId = Number(chatIdRaw);
-                if (!Number.isFinite(chatId)) {
-                    return jsonResponse({ error: 'Invalid chat id' }, 400);
-                }
-
-                const allowed = await canEditChatConfig(
-                    options.bot,
-                    globalConfig,
-                    chatId,
-                    userId,
-                );
-                if (!allowed) {
-                    return jsonResponse({ error: 'Forbidden' }, 403);
-                }
-
-                const body = await req.json() as { payload?: unknown };
-                if (!body.payload) {
-                    return jsonResponse({ error: 'Missing payload' }, 400);
-                }
-
-                const parsedOverride = parseChatOverridePayload(
-                    JSON.stringify(body.payload),
-                );
-                const sanitizedOverride = sanitizeChatOverrideForRole(
-                    parsedOverride,
-                    role,
-                    globalConfig,
-                );
-                const chatMemory = new ChatMemory(
-                    options.memory,
-                    await options.bot.api.getChat(chatId),
-                );
-                await chatMemory.setChatConfigOverride(
-                    sanitizedOverride,
-                    userId,
-                );
-
-                return jsonResponse({ ok: true });
-            }
-
-            return new Response('Not found', { status: 404 });
+            })();
         } catch (error) {
-            logger.error('Web API error: ', error);
-            const message = error instanceof Error
-                ? error.message
-                : 'Unknown error';
-            return jsonResponse({ error: message }, 400);
+            logger.error('Unhandled web server error: ', error);
+            response = jsonResponse({ error: 'Internal server error' }, 500);
         }
+
+        const status = statusClass(response.status);
+        const durationSeconds = (performance.now() - startedAt) / 1000;
+        httpRequestsTotal.inc({
+            route: routeTemplate,
+            method: req.method,
+            status_class: status,
+        });
+        httpRequestDurationSeconds.observe({
+            route: routeTemplate,
+            method: req.method,
+            status_class: status,
+        }, durationSeconds);
+
+        return response;
     });
 
     logger.info(`Web server started on ${hostname}:${port}`);


### PR DESCRIPTION
## Summary
- add an in-process Prometheus registry in `lib/app/metrics.ts` with counters, gauges, histograms, and text exposition
- expose `GET /metrics` in the web server and instrument HTTP request totals/duration using low-cardinality route templates
- instrument Telegram update/error paths, AI generation flows (chat/notes/memory/character), usage-window events, and rate-limit exceed callbacks

## Validation
- `deno check --allow-import main.ts`
- `deno lint`
- `AI_TOKEN=\"test\" deno test -A`
- `scripts/build.bash`