### PR TITLE
Refactor settings override merging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM --platform=$BUILDPLATFORM denoland/deno:2.7.4 AS widget-builder
 WORKDIR /app
 
 COPY widget ./widget
+COPY lib/config-contract.ts ./lib/config-contract.ts
 
 RUN deno task --config ./widget/deno.json build
 

--- a/lib/config-contract.ts
+++ b/lib/config-contract.ts
@@ -1,0 +1,54 @@
+export const chatOverrideContract = {
+    regularDirect: [
+        'names',
+        'tendToReply',
+        'tendToIgnore',
+        'blacklistedReactions',
+        'nepons',
+    ],
+    regularDelta: [
+        'tendToReplyProbability',
+        'tendToIgnoreProbability',
+        'randomReplyProbability',
+        'responseDelay',
+    ],
+    trustedAi: [
+        'model',
+        'temperature',
+        'topK',
+        'topP',
+        'historyVersion',
+        'prompt',
+        'dumbPrompt',
+        'privateChatPromptAddition',
+        'groupChatPromptAddition',
+        'commentsPromptAddition',
+        'hateModePrompt',
+        'replyMethod',
+        'messagesToPass',
+        'messageMaxLength',
+        'includeAttachmentsInHistory',
+        'bytesLimit',
+    ],
+    adminWindow: [
+        'requestWindowPerChat.free.maxRequests',
+        'requestWindowPerChat.free.windowMinutes',
+        'requestWindowPerChat.trusted.maxRequests',
+        'requestWindowPerChat.trusted.windowMinutes',
+    ],
+} as const;
+
+export type RegularDirectChatOverridePath =
+    typeof chatOverrideContract.regularDirect[number];
+export type RegularDeltaChatOverridePath =
+    typeof chatOverrideContract.regularDelta[number];
+export type TrustedAiChatOverrideKey =
+    typeof chatOverrideContract.trustedAi[number];
+export type AdminWindowChatOverridePath =
+    typeof chatOverrideContract.adminWindow[number];
+
+export type ChatOverridePath =
+    | RegularDirectChatOverridePath
+    | RegularDeltaChatOverridePath
+    | `ai.${TrustedAiChatOverrideKey}`
+    | AdminWindowChatOverridePath;

--- a/lib/web/config-policy.ts
+++ b/lib/web/config-policy.ts
@@ -3,6 +3,45 @@ import { ConfigRole } from './permissions.ts';
 import { normalizeReactionBlacklist } from '../telegram/reactions.ts';
 
 type ChatEditableAi = NonNullable<ChatConfigOverride['ai']>;
+type ChatOverrideKey = keyof Omit<
+    ChatConfigOverride,
+    'ai' | 'requestWindowPerChat'
+>;
+type ChatEditableAiKey = keyof ChatEditableAi;
+
+const regularDirectOverrideKeys = [
+    'names',
+    'tendToReply',
+    'tendToIgnore',
+    'blacklistedReactions',
+    'nepons',
+] as const satisfies readonly ChatOverrideKey[];
+
+const regularDeltaOverrideKeys = [
+    'tendToReplyProbability',
+    'tendToIgnoreProbability',
+    'randomReplyProbability',
+    'responseDelay',
+] as const satisfies readonly ChatOverrideKey[];
+
+const trustedAiKeys = [
+    'model',
+    'temperature',
+    'topK',
+    'topP',
+    'historyVersion',
+    'prompt',
+    'dumbPrompt',
+    'privateChatPromptAddition',
+    'groupChatPromptAddition',
+    'commentsPromptAddition',
+    'hateModePrompt',
+    'replyMethod',
+    'messagesToPass',
+    'messageMaxLength',
+    'includeAttachmentsInHistory',
+    'bytesLimit',
+] as const satisfies readonly ChatEditableAiKey[];
 
 function uniqueModels(models: string[]): string[] {
     return Array.from(new Set(models.map((item) => item.trim()))).filter((
@@ -20,46 +59,13 @@ function resolveAvailableModels(config: UserConfig): string[] {
     ]);
 }
 
-function pickTrustedAi(config: UserConfig['ai']): ChatEditableAi {
-    return {
-        model: config.model,
-        temperature: config.temperature,
-        topK: config.topK,
-        topP: config.topP,
-        historyVersion: config.historyVersion,
-        prompt: config.prompt,
-        dumbPrompt: config.dumbPrompt,
-        privateChatPromptAddition: config.privateChatPromptAddition,
-        groupChatPromptAddition: config.groupChatPromptAddition,
-        commentsPromptAddition: config.commentsPromptAddition,
-        hateModePrompt: config.hateModePrompt,
-        replyMethod: config.replyMethod,
-        messagesToPass: config.messagesToPass,
-        messageMaxLength: config.messageMaxLength,
-        includeAttachmentsInHistory: config.includeAttachmentsInHistory,
-        bytesLimit: config.bytesLimit,
-    };
-}
-
-function pickTrustedAiOverride(config: ChatEditableAi): ChatEditableAi {
-    return {
-        model: config.model,
-        temperature: config.temperature,
-        topK: config.topK,
-        topP: config.topP,
-        historyVersion: config.historyVersion,
-        prompt: config.prompt,
-        dumbPrompt: config.dumbPrompt,
-        privateChatPromptAddition: config.privateChatPromptAddition,
-        groupChatPromptAddition: config.groupChatPromptAddition,
-        commentsPromptAddition: config.commentsPromptAddition,
-        hateModePrompt: config.hateModePrompt,
-        replyMethod: config.replyMethod,
-        messagesToPass: config.messagesToPass,
-        messageMaxLength: config.messageMaxLength,
-        includeAttachmentsInHistory: config.includeAttachmentsInHistory,
-        bytesLimit: config.bytesLimit,
-    };
+function pickTrustedAi(config: Partial<UserConfig['ai']>): ChatEditableAi {
+    const picked: Record<string, unknown> = {};
+    for (const key of trustedAiKeys) {
+        picked[key] = config[key];
+    }
+    // Key iteration loses field correlation; trustedAiKeys constrains the shape.
+    return picked as ChatEditableAi;
 }
 
 function hasDefinedValues(value: Record<string, unknown>): boolean {
@@ -71,6 +77,38 @@ function hasDefinedPrimitiveDelta<T>(
     base: T,
 ): value is T {
     return value !== undefined && value !== base;
+}
+
+function copyDefinedOverrides(
+    source: ChatConfigOverride,
+    target: ChatConfigOverride,
+    keys: readonly ChatOverrideKey[],
+): void {
+    // Key iteration loses field correlation; keys are constrained by ChatOverrideKey.
+    const targetRecord = target as Record<string, unknown>;
+    for (const key of keys) {
+        const value = source[key];
+        if (value !== undefined) {
+            targetRecord[key] = value;
+        }
+    }
+}
+
+function copyPrimitiveDeltas(
+    source: ChatConfigOverride,
+    target: ChatConfigOverride,
+    base: UserConfig,
+    keys: readonly ChatOverrideKey[],
+): void {
+    // Key iteration loses field correlation; keys are constrained by ChatOverrideKey.
+    const targetRecord = target as Record<string, unknown>;
+    for (const key of keys) {
+        const value = source[key];
+        const baseValue = base[key as keyof UserConfig];
+        if (value !== undefined && value !== baseValue) {
+            targetRecord[key] = value;
+        }
+    }
 }
 
 export function buildBootstrapCapabilities(role: ConfigRole): {
@@ -141,6 +179,17 @@ export function projectEffectiveConfigForRole(
     return base;
 }
 
+export function projectChatBaseConfigForRole(
+    config: UserConfig,
+    role: ConfigRole,
+): Record<string, unknown> {
+    const payload = projectEffectiveConfigForRole(config, role);
+    if (role === 'admin') {
+        payload.requestWindow = config.requestWindow;
+    }
+    return payload;
+}
+
 export function sanitizeChatOverrideForRole(
     override: ChatConfigOverride,
     role: ConfigRole,
@@ -153,49 +202,13 @@ export function sanitizeChatOverrideForRole(
 
     const next: ChatConfigOverride = {};
 
-    if (override.names !== undefined) next.names = override.names;
-    if (override.tendToReply !== undefined) {
-        next.tendToReply = override.tendToReply;
-    }
-    if (
-        hasDefinedPrimitiveDelta(
-            override.tendToReplyProbability,
-            globalConfig.tendToReplyProbability,
-        )
-    ) {
-        next.tendToReplyProbability = override.tendToReplyProbability;
-    }
-    if (override.tendToIgnore !== undefined) {
-        next.tendToIgnore = override.tendToIgnore;
-    }
-    if (
-        hasDefinedPrimitiveDelta(
-            override.tendToIgnoreProbability,
-            globalConfig.tendToIgnoreProbability,
-        )
-    ) {
-        next.tendToIgnoreProbability = override.tendToIgnoreProbability;
-    }
-    if (
-        hasDefinedPrimitiveDelta(
-            override.randomReplyProbability,
-            globalConfig.randomReplyProbability,
-        )
-    ) {
-        next.randomReplyProbability = override.randomReplyProbability;
-    }
-    if (override.blacklistedReactions !== undefined) {
-        next.blacklistedReactions = override.blacklistedReactions;
-    }
-    if (override.nepons !== undefined) next.nepons = override.nepons;
-    if (
-        hasDefinedPrimitiveDelta(
-            override.responseDelay,
-            globalConfig.responseDelay,
-        )
-    ) {
-        next.responseDelay = override.responseDelay;
-    }
+    copyDefinedOverrides(override, next, regularDirectOverrideKeys);
+    copyPrimitiveDeltas(
+        override,
+        next,
+        globalConfig,
+        regularDeltaOverrideKeys,
+    );
     if (role === 'admin' && override.requestWindowPerChat !== undefined) {
         next.requestWindowPerChat = override.requestWindowPerChat;
     }
@@ -220,7 +233,7 @@ export function sanitizeChatOverrideForRole(
     }
 
     if ((role === 'trusted' || role === 'admin') && override.ai) {
-        const ai = pickTrustedAiOverride(override.ai);
+        const ai = pickTrustedAi(override.ai);
         const availableModels = resolveAvailableModels(globalConfig);
 
         if (ai.model && !availableModels.includes(ai.model)) {
@@ -232,108 +245,11 @@ export function sanitizeChatOverrideForRole(
         }
 
         const aiDelta: Partial<ChatEditableAi> = {};
-        if (hasDefinedPrimitiveDelta(ai.model, globalConfig.ai.model)) {
-            aiDelta.model = ai.model;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.temperature,
-                globalConfig.ai.temperature,
-            )
-        ) {
-            aiDelta.temperature = ai.temperature;
-        }
-        if (hasDefinedPrimitiveDelta(ai.topK, globalConfig.ai.topK)) {
-            aiDelta.topK = ai.topK;
-        }
-        if (hasDefinedPrimitiveDelta(ai.topP, globalConfig.ai.topP)) {
-            aiDelta.topP = ai.topP;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.historyVersion,
-                globalConfig.ai.historyVersion,
-            )
-        ) {
-            aiDelta.historyVersion = ai.historyVersion;
-        }
-        if (hasDefinedPrimitiveDelta(ai.prompt, globalConfig.ai.prompt)) {
-            aiDelta.prompt = ai.prompt;
-        }
-        if (
-            hasDefinedPrimitiveDelta(ai.dumbPrompt, globalConfig.ai.dumbPrompt)
-        ) {
-            aiDelta.dumbPrompt = ai.dumbPrompt;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.privateChatPromptAddition,
-                globalConfig.ai.privateChatPromptAddition,
-            )
-        ) {
-            aiDelta.privateChatPromptAddition = ai.privateChatPromptAddition;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.groupChatPromptAddition,
-                globalConfig.ai.groupChatPromptAddition,
-            )
-        ) {
-            aiDelta.groupChatPromptAddition = ai.groupChatPromptAddition;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.commentsPromptAddition,
-                globalConfig.ai.commentsPromptAddition,
-            )
-        ) {
-            aiDelta.commentsPromptAddition = ai.commentsPromptAddition;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.hateModePrompt,
-                globalConfig.ai.hateModePrompt,
-            )
-        ) {
-            aiDelta.hateModePrompt = ai.hateModePrompt;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.replyMethod,
-                globalConfig.ai.replyMethod,
-            )
-        ) {
-            aiDelta.replyMethod = ai.replyMethod;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.messagesToPass,
-                globalConfig.ai.messagesToPass,
-            )
-        ) {
-            aiDelta.messagesToPass = ai.messagesToPass;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.messageMaxLength,
-                globalConfig.ai.messageMaxLength,
-            )
-        ) {
-            aiDelta.messageMaxLength = ai.messageMaxLength;
-        }
-        if (
-            hasDefinedPrimitiveDelta(
-                ai.includeAttachmentsInHistory,
-                globalConfig.ai.includeAttachmentsInHistory,
-            )
-        ) {
-            aiDelta.includeAttachmentsInHistory =
-                ai.includeAttachmentsInHistory;
-        }
-        if (
-            hasDefinedPrimitiveDelta(ai.bytesLimit, globalConfig.ai.bytesLimit)
-        ) {
-            aiDelta.bytesLimit = ai.bytesLimit;
+        const aiDeltaRecord = aiDelta as Record<string, unknown>;
+        for (const key of trustedAiKeys) {
+            if (hasDefinedPrimitiveDelta(ai[key], globalConfig.ai[key])) {
+                aiDeltaRecord[key] = ai[key];
+            }
         }
 
         if (hasDefinedValues(aiDelta as Record<string, unknown>)) {

--- a/lib/web/config-policy.ts
+++ b/lib/web/config-policy.ts
@@ -1,4 +1,5 @@
 import { ChatConfigOverride, UserConfig } from '../config.ts';
+import { chatOverrideContract } from '../config-contract.ts';
 import { ConfigRole } from './permissions.ts';
 import { normalizeReactionBlacklist } from '../telegram/reactions.ts';
 
@@ -9,39 +10,12 @@ type ChatOverrideKey = keyof Omit<
 >;
 type ChatEditableAiKey = keyof ChatEditableAi;
 
-const regularDirectOverrideKeys = [
-    'names',
-    'tendToReply',
-    'tendToIgnore',
-    'blacklistedReactions',
-    'nepons',
-] as const satisfies readonly ChatOverrideKey[];
-
-const regularDeltaOverrideKeys = [
-    'tendToReplyProbability',
-    'tendToIgnoreProbability',
-    'randomReplyProbability',
-    'responseDelay',
-] as const satisfies readonly ChatOverrideKey[];
-
-const trustedAiKeys = [
-    'model',
-    'temperature',
-    'topK',
-    'topP',
-    'historyVersion',
-    'prompt',
-    'dumbPrompt',
-    'privateChatPromptAddition',
-    'groupChatPromptAddition',
-    'commentsPromptAddition',
-    'hateModePrompt',
-    'replyMethod',
-    'messagesToPass',
-    'messageMaxLength',
-    'includeAttachmentsInHistory',
-    'bytesLimit',
-] as const satisfies readonly ChatEditableAiKey[];
+const regularDirectOverrideKeys = chatOverrideContract
+    .regularDirect satisfies readonly ChatOverrideKey[];
+const regularDeltaOverrideKeys = chatOverrideContract
+    .regularDelta satisfies readonly ChatOverrideKey[];
+const trustedAiKeys = chatOverrideContract
+    .trustedAi satisfies readonly ChatEditableAiKey[];
 
 function uniqueModels(models: string[]): string[] {
     return Array.from(new Set(models.map((item) => item.trim()))).filter((

--- a/lib/web/handlers/bootstrap.ts
+++ b/lib/web/handlers/bootstrap.ts
@@ -16,6 +16,7 @@ import {
 import {
     buildBootstrapCapabilities,
     getModelOptionsForRole,
+    projectChatBaseConfigForRole,
     projectEffectiveConfigForRole,
     projectGlobalConfigForRole,
     sanitizeChatOverrideForRole,
@@ -183,16 +184,10 @@ export async function handleBootstrapRequest(
         serializedGlobalConfig,
         role,
     );
-    let chatBasePayload = projectEffectiveConfigForRole(
+    const chatBasePayload = projectChatBaseConfigForRole(
         serializedGlobalConfig,
         role,
     );
-    if (role === 'admin') {
-        chatBasePayload = {
-            ...chatBasePayload,
-            requestWindow: serializedGlobalConfig.requestWindow,
-        };
-    }
 
     let chatOverridePayload: unknown = undefined;
     let effectiveConfigPayload: unknown = undefined;

--- a/widget/src/App.svelte
+++ b/widget/src/App.svelte
@@ -5,7 +5,8 @@
     import { onDestroy, onMount, untrack } from 'svelte';
     import ChatOverrideForm from '$lib/components/config/ChatOverrideForm.svelte';
     import ConfigToolbar from '$lib/components/config/ConfigToolbar.svelte';
-    import { buildChatPayload, buildGlobalPayload, collectChatOverridePaths } from '$lib/config/model';
+    import { buildGlobalPayload } from '$lib/config/model';
+    import { buildChatPayload, collectChatOverridePaths } from '$lib/config/override';
     import GlobalConfigForm from '$lib/components/config/GlobalConfigForm.svelte';
     import { createConfigController } from '$lib/config/controller.svelte';
     import { Button } from '$lib/components/ui/button';

--- a/widget/src/lib/components/config/ChatOverrideForm.svelte
+++ b/widget/src/lib/components/config/ChatOverrideForm.svelte
@@ -10,9 +10,9 @@
     import { createSectionMatcher } from '$lib/components/config/search';
     import { useI18n } from '$lib/i18n/context.svelte';
     import {
-        matcherListToTextarea,
-        stringListToTextarea,
-    } from '$lib/config/model';
+        resetChatOverridePath,
+        type ChatOverridePath,
+    } from '$lib/config/override';
     import type {
         ChatInternalsPayload,
         ChatFormText,
@@ -31,7 +31,7 @@
         canEditChatInternals: boolean;
         canConfigureTrustedSettings: boolean;
         canEditWindowOverrides: boolean;
-        overriddenFieldPaths: string[];
+        overriddenFieldPaths: ChatOverridePath[];
         searchQuery: string;
     }
 
@@ -146,20 +146,20 @@
     );
     let overriddenPathSet = $derived(new Set(overriddenFieldPaths));
 
-    const isOverridden = (path: string): boolean => overriddenPathSet.has(path);
+    const isOverridden = (path: ChatOverridePath): boolean => overriddenPathSet.has(path);
 
-    const unsetIfOverridden = (path: string, onUnset: () => void): void => {
+    const unsetIfOverridden = (path: ChatOverridePath): void => {
         if (!isOverridden(path)) {
             return;
         }
 
-        onUnset();
+        resetChatOverridePath(path, config, text, baseConfig);
     };
 
-    const sourceStateFor = (path: string, onUnset: () => void) => ({
+    const sourceStateFor = (path: ChatOverridePath) => ({
         overridden: isOverridden(path),
         label: 'Unset chat override (inherit global value)',
-        onUnset: () => unsetIfOverridden(path, onUnset),
+        onUnset: () => unsetIfOverridden(path),
     });
 
 </script>
@@ -253,9 +253,7 @@
                             type="number"
                             label="Reply tendency (%)"
                             description="Chance to answer when tend-to-reply patterns match."
-                            sourceState={sourceStateFor('tendToReplyProbability', () => {
-                                config.tendToReplyProbability = baseConfig.tendToReplyProbability;
-                            })}
+                            sourceState={sourceStateFor('tendToReplyProbability')}
                             hidden={!matchesBlockItem('general', 'reply tendency', 'tend to reply probability')}
                             bind:value={config.tendToReplyProbability}
                         />
@@ -264,9 +262,7 @@
                             type="number"
                             label="Ignore tendency (%)"
                             description="Chance to ignore when tend-to-ignore patterns match."
-                            sourceState={sourceStateFor('tendToIgnoreProbability', () => {
-                                config.tendToIgnoreProbability = baseConfig.tendToIgnoreProbability;
-                            })}
+                            sourceState={sourceStateFor('tendToIgnoreProbability')}
                             hidden={!matchesBlockItem('general', 'ignore tendency', 'tend to ignore probability')}
                             bind:value={config.tendToIgnoreProbability}
                         />
@@ -275,9 +271,7 @@
                             type="number"
                             label="Random reply chance (%)"
                             description="Fallback probability to respond without a match."
-                            sourceState={sourceStateFor('randomReplyProbability', () => {
-                                config.randomReplyProbability = baseConfig.randomReplyProbability;
-                            })}
+                            sourceState={sourceStateFor('randomReplyProbability')}
                             hidden={!matchesBlockItem('general', 'random reply chance', 'random reply probability')}
                             bind:value={config.randomReplyProbability}
                         />
@@ -286,9 +280,7 @@
                             type="number"
                             label="Response delay (seconds)"
                             description="Wait time before sending the reply."
-                            sourceState={sourceStateFor('responseDelay', () => {
-                                config.responseDelay = baseConfig.responseDelay;
-                            })}
+                            sourceState={sourceStateFor('responseDelay')}
                             hidden={!matchesBlockItem('general', 'response delay')}
                             bind:value={config.responseDelay}
                         />
@@ -297,9 +289,7 @@
                             label="History version"
                             description="Selects conversation history builder for this chat."
                             options={['v2', 'v3']}
-                            sourceState={sourceStateFor('ai.historyVersion', () => {
-                                config.ai.historyVersion = baseConfig.ai.historyVersion;
-                            })}
+                            sourceState={sourceStateFor('ai.historyVersion')}
                             hidden={!matchesBlockItem('general', 'history version', 'ai.historyVersion')}
                             bind:value={config.ai.historyVersion}
                         />
@@ -310,10 +300,7 @@
                             id="c-names"
                             label="Bot names"
                             description="One name or regex per line; used for mentions."
-                            sourceState={sourceStateFor('names', () => {
-                                config.names = [...baseConfig.names];
-                                text.names = matcherListToTextarea(baseConfig.names);
-                            })}
+                            sourceState={sourceStateFor('names')}
                             hidden={!matchesBlockItem('general', 'bot names', 'names')}
                             bind:value={text.names}
                         />
@@ -321,10 +308,7 @@
                             id="c-tend-reply"
                             label="Reply trigger patterns"
                             description="One pattern per line; supports /regex/flags."
-                            sourceState={sourceStateFor('tendToReply', () => {
-                                config.tendToReply = [...baseConfig.tendToReply];
-                                text.tendToReply = matcherListToTextarea(baseConfig.tendToReply);
-                            })}
+                            sourceState={sourceStateFor('tendToReply')}
                             hidden={!matchesBlockItem('general', 'reply trigger patterns', 'tend to reply')}
                             bind:value={text.tendToReply}
                         />
@@ -332,10 +316,7 @@
                             id="c-tend-ignore"
                             label="Ignore trigger patterns"
                             description="One pattern per line; supports /regex/flags."
-                            sourceState={sourceStateFor('tendToIgnore', () => {
-                                config.tendToIgnore = [...baseConfig.tendToIgnore];
-                                text.tendToIgnore = matcherListToTextarea(baseConfig.tendToIgnore);
-                            })}
+                            sourceState={sourceStateFor('tendToIgnore')}
                             hidden={!matchesBlockItem('general', 'ignore trigger patterns', 'tend to ignore')}
                             bind:value={text.tendToIgnore}
                         />
@@ -344,10 +325,7 @@
                             label="Blacklisted reactions"
                             description="Select reactions to block in this chat. Unselected reactions stay allowed."
                             reactions={availableReactions}
-                            sourceState={sourceStateFor('blacklistedReactions', () => {
-                                config.blacklistedReactions = [...baseConfig.blacklistedReactions];
-                                text.blacklistedReactions = stringListToTextarea(baseConfig.blacklistedReactions);
-                            })}
+                            sourceState={sourceStateFor('blacklistedReactions')}
                             hidden={!matchesBlockItem('general', 'blacklisted reactions', 'reactions')}
                             bind:value={text.blacklistedReactions}
                         />
@@ -357,10 +335,7 @@
                             description="Add, reorder, and remove canned fallback replies."
                             itemPlaceholder="Fallback reply"
                             addLabel="Add reply"
-                            sourceState={sourceStateFor('nepons', () => {
-                                config.nepons = [...baseConfig.nepons];
-                                text.nepons = stringListToTextarea(baseConfig.nepons);
-                            })}
+                            sourceState={sourceStateFor('nepons')}
                             hidden={!matchesBlockItem('general', 'nepon replies', 'nepons')}
                             bind:value={text.nepons}
                         />
@@ -405,9 +380,7 @@
                             label="Model"
                             description="Model used for this chat override."
                             options={availableModels}
-                            sourceState={sourceStateFor('ai.model', () => {
-                                config.ai.model = baseConfig.ai.model;
-                            })}
+                            sourceState={sourceStateFor('ai.model')}
                             hidden={!matchesBlockItem('model', 'model', 'ai model')}
                             bind:value={config.ai.model}
                         />
@@ -416,9 +389,7 @@
                             type="number"
                             label="Temperature"
                             description="Higher values increase randomness."
-                            sourceState={sourceStateFor('ai.temperature', () => {
-                                config.ai.temperature = baseConfig.ai.temperature;
-                            })}
+                            sourceState={sourceStateFor('ai.temperature')}
                             hidden={!matchesBlockItem('model', 'temperature')}
                             bind:value={config.ai.temperature}
                         />
@@ -427,9 +398,7 @@
                             type="number"
                             label="Top-K"
                             description="Limits token choices to the top K candidates."
-                            sourceState={sourceStateFor('ai.topK', () => {
-                                config.ai.topK = baseConfig.ai.topK;
-                            })}
+                            sourceState={sourceStateFor('ai.topK')}
                             hidden={!matchesBlockItem('model', 'top-k', 'topk')}
                             bind:value={config.ai.topK}
                         />
@@ -438,9 +407,7 @@
                             type="number"
                             label="Top-P"
                             description="Uses nucleus sampling with cumulative probability P."
-                            sourceState={sourceStateFor('ai.topP', () => {
-                                config.ai.topP = baseConfig.ai.topP;
-                            })}
+                            sourceState={sourceStateFor('ai.topP')}
                             hidden={!matchesBlockItem('model', 'top-p', 'topp')}
                             bind:value={config.ai.topP}
                         />
@@ -458,9 +425,7 @@
                             containerClass="md:col-span-2"
                             label="JSON-actions chat prompt"
                             description="Core behavior/persona prompt used only when reply method is json_actions."
-                            sourceState={sourceStateFor('ai.prompt', () => {
-                                config.ai.prompt = baseConfig.ai.prompt;
-                            })}
+                            sourceState={sourceStateFor('ai.prompt')}
                             hidden={!matchesBlockItem('prompts', 'json-actions chat prompt', 'primary chat prompt')}
                             bind:value={config.ai.prompt}
                         />
@@ -470,9 +435,7 @@
                             containerClass="md:col-span-2"
                             label="Plain-text chat prompt"
                             description="Core behavior/persona prompt used only when reply method is plain_text_reactions."
-                            sourceState={sourceStateFor('ai.dumbPrompt', () => {
-                                config.ai.dumbPrompt = baseConfig.ai.dumbPrompt;
-                            })}
+                            sourceState={sourceStateFor('ai.dumbPrompt')}
                             hidden={!matchesBlockItem('prompts', 'plain-text chat prompt', 'low-context chat prompt', 'dumb prompt')}
                             bind:value={config.ai.dumbPrompt}
                         />
@@ -482,9 +445,7 @@
                             containerClass="md:col-span-2"
                             label="Private chat prompt addition"
                             description="Extra instructions for private chats in this chat."
-                            sourceState={sourceStateFor('ai.privateChatPromptAddition', () => {
-                                config.ai.privateChatPromptAddition = baseConfig.ai.privateChatPromptAddition;
-                            })}
+                            sourceState={sourceStateFor('ai.privateChatPromptAddition')}
                             hidden={!matchesBlockItem('prompts', 'private chat prompt addition')}
                             bind:value={config.ai.privateChatPromptAddition}
                         />
@@ -494,9 +455,7 @@
                             containerClass="md:col-span-2"
                             label="Group chat prompt addition"
                             description="Extra instructions for group chats in this chat."
-                            sourceState={sourceStateFor('ai.groupChatPromptAddition', () => {
-                                config.ai.groupChatPromptAddition = baseConfig.ai.groupChatPromptAddition;
-                            })}
+                            sourceState={sourceStateFor('ai.groupChatPromptAddition')}
                             hidden={!matchesBlockItem('prompts', 'group chat prompt addition')}
                             bind:value={config.ai.groupChatPromptAddition}
                         />
@@ -506,9 +465,7 @@
                             containerClass="md:col-span-2"
                             label="Comment prompt addition"
                             description="Extra guidance for comment-style messages."
-                            sourceState={sourceStateFor('ai.commentsPromptAddition', () => {
-                                config.ai.commentsPromptAddition = baseConfig.ai.commentsPromptAddition;
-                            })}
+                            sourceState={sourceStateFor('ai.commentsPromptAddition')}
                             hidden={!matchesBlockItem('prompts', 'comment prompt addition', 'comments prompt addition')}
                             bind:value={config.ai.commentsPromptAddition}
                         />
@@ -518,9 +475,7 @@
                             containerClass="md:col-span-2"
                             label="Hate mode prompt"
                             description="Special prompt used when hate mode is enabled."
-                            sourceState={sourceStateFor('ai.hateModePrompt', () => {
-                                config.ai.hateModePrompt = baseConfig.ai.hateModePrompt;
-                            })}
+                            sourceState={sourceStateFor('ai.hateModePrompt')}
                             hidden={!matchesBlockItem('prompts', 'hate mode prompt')}
                             bind:value={config.ai.hateModePrompt}
                         />
@@ -537,9 +492,7 @@
                             type="number"
                             label="Messages passed to AI"
                             description="Number of recent messages sent to the model."
-                            sourceState={sourceStateFor('ai.messagesToPass', () => {
-                                config.ai.messagesToPass = baseConfig.ai.messagesToPass;
-                            })}
+                            sourceState={sourceStateFor('ai.messagesToPass')}
                             hidden={!matchesBlockItem('advanced', 'messages passed to ai')}
                             bind:value={config.ai.messagesToPass}
                         />
@@ -548,9 +501,7 @@
                             type="number"
                             label="Max reply length (chars)"
                             description="Soft limit for generated response length."
-                            sourceState={sourceStateFor('ai.messageMaxLength', () => {
-                                config.ai.messageMaxLength = baseConfig.ai.messageMaxLength;
-                            })}
+                            sourceState={sourceStateFor('ai.messageMaxLength')}
                             hidden={!matchesBlockItem('advanced', 'max reply length', 'message max length')}
                             bind:value={config.ai.messageMaxLength}
                         />
@@ -559,9 +510,7 @@
                             type="number"
                             label="Attachment byte limit"
                             description="Maximum attachment size included in processing."
-                            sourceState={sourceStateFor('ai.bytesLimit', () => {
-                                config.ai.bytesLimit = baseConfig.ai.bytesLimit;
-                            })}
+                            sourceState={sourceStateFor('ai.bytesLimit')}
                             hidden={!matchesBlockItem('advanced', 'attachment byte limit', 'bytes limit')}
                             bind:value={config.ai.bytesLimit}
                         />
@@ -570,9 +519,7 @@
                             label="Reply method"
                             description="Chooses how replies and reactions are generated in this chat."
                             options={['json_actions', 'plain_text_reactions']}
-                            sourceState={sourceStateFor('ai.replyMethod', () => {
-                                config.ai.replyMethod = baseConfig.ai.replyMethod;
-                            })}
+                            sourceState={sourceStateFor('ai.replyMethod')}
                             hidden={!matchesBlockItem('advanced', 'reply method', 'ai.replyMethod')}
                             bind:value={config.ai.replyMethod}
                         />
@@ -580,9 +527,7 @@
                             id="c-ai-attachments"
                             label="Include attachments in history"
                             description="Adds attachment text to model context when possible."
-                            sourceState={sourceStateFor('ai.includeAttachmentsInHistory', () => {
-                                config.ai.includeAttachmentsInHistory = baseConfig.ai.includeAttachmentsInHistory;
-                            })}
+                            sourceState={sourceStateFor('ai.includeAttachmentsInHistory')}
                             hidden={!matchesBlockItem('advanced', 'include attachments in history')}
                             bind:checked={config.ai.includeAttachmentsInHistory}
                         />
@@ -599,10 +544,7 @@
                             type="number"
                             label="Free tier per-chat max requests"
                             description="Chat-wide free-tier limit before cost mode."
-                            sourceState={sourceStateFor('requestWindowPerChat.free.maxRequests', () => {
-                                config.requestWindowPerChat.free.maxRequests =
-                                    baseConfig.requestWindowPerChat.free.maxRequests;
-                            })}
+                            sourceState={sourceStateFor('requestWindowPerChat.free.maxRequests')}
                             hidden={!matchesBlockItem('usage limits', 'free tier per-chat max requests')}
                             bind:value={config.requestWindowPerChat.free.maxRequests}
                         />
@@ -611,10 +553,7 @@
                             type="number"
                             label="Free tier per-chat window (minutes)"
                             description="Rolling window for free-tier chat usage."
-                            sourceState={sourceStateFor('requestWindowPerChat.free.windowMinutes', () => {
-                                config.requestWindowPerChat.free.windowMinutes =
-                                    baseConfig.requestWindowPerChat.free.windowMinutes;
-                            })}
+                            sourceState={sourceStateFor('requestWindowPerChat.free.windowMinutes')}
                             hidden={!matchesBlockItem('usage limits', 'free tier per-chat window minutes')}
                             bind:value={config.requestWindowPerChat.free.windowMinutes}
                         />
@@ -623,10 +562,7 @@
                             type="number"
                             label="Trusted tier per-chat max requests"
                             description="Chat-wide trusted-tier limit before cost mode."
-                            sourceState={sourceStateFor('requestWindowPerChat.trusted.maxRequests', () => {
-                                config.requestWindowPerChat.trusted.maxRequests =
-                                    baseConfig.requestWindowPerChat.trusted.maxRequests;
-                            })}
+                            sourceState={sourceStateFor('requestWindowPerChat.trusted.maxRequests')}
                             hidden={!matchesBlockItem('usage limits', 'trusted tier per-chat max requests')}
                             bind:value={config.requestWindowPerChat.trusted.maxRequests}
                         />
@@ -635,10 +571,7 @@
                             type="number"
                             label="Trusted tier per-chat window (minutes)"
                             description="Rolling window for trusted-tier chat usage."
-                            sourceState={sourceStateFor('requestWindowPerChat.trusted.windowMinutes', () => {
-                                config.requestWindowPerChat.trusted.windowMinutes =
-                                    baseConfig.requestWindowPerChat.trusted.windowMinutes;
-                            })}
+                            sourceState={sourceStateFor('requestWindowPerChat.trusted.windowMinutes')}
                             hidden={!matchesBlockItem('usage limits', 'trusted tier per-chat window minutes')}
                             bind:value={config.requestWindowPerChat.trusted.windowMinutes}
                         />

--- a/widget/src/lib/config/controller.svelte.ts
+++ b/widget/src/lib/config/controller.svelte.ts
@@ -5,6 +5,7 @@ import {
   saveChatInternals,
   saveGlobalConfig,
 } from "./api";
+import { buildChatPayload } from "./override";
 import {
   DEFAULT_LOCALE,
   normalizeLocale,
@@ -14,7 +15,6 @@ import {
 import {
   type AvailableChat,
   type BootstrapResponse,
-  buildChatPayload,
   buildGlobalPayload,
   type ChatFormText,
   type ChatInternalsPayload,
@@ -24,7 +24,6 @@ import {
   type CurrentCharacterPayload,
   defaultGlobalConfig,
   fromUnknownChatInternals,
-  fromUnknownChatOverride,
   fromUnknownCurrentCharacter,
   fromUnknownGlobal,
   fromUnknownUsageWindowStatus,
@@ -32,6 +31,7 @@ import {
   globalTextFromConfig,
   parseChatIdFromStartParam,
   type ResolvedChatOverridePayload,
+  resolveChatOverridePayload,
   type UsageWindowStatus,
 } from "./model";
 
@@ -102,10 +102,10 @@ export class ConfigController {
   });
 
   chatOverrideConfig = $state(
-    fromUnknownChatOverride({}, defaultGlobalConfig()),
+    resolveChatOverridePayload({}, defaultGlobalConfig()),
   );
   chatBaseConfig = $state<ResolvedChatOverridePayload>(
-    fromUnknownChatOverride({}, defaultGlobalConfig()),
+    resolveChatOverridePayload({}, defaultGlobalConfig()),
   );
   chatText = $state<ChatFormText>({
     names: "",
@@ -211,8 +211,8 @@ export class ConfigController {
     const baseConfig = fromUnknownGlobal(
       data.chatBasePayload ?? data.globalPayload ?? data.effectiveConfigPayload,
     );
-    this.chatBaseConfig = fromUnknownChatOverride({}, baseConfig);
-    this.chatOverrideConfig = fromUnknownChatOverride(
+    this.chatBaseConfig = resolveChatOverridePayload({}, baseConfig);
+    this.chatOverrideConfig = resolveChatOverridePayload(
       data.chatOverridePayload,
       baseConfig,
     );

--- a/widget/src/lib/config/controller.svelte.ts
+++ b/widget/src/lib/config/controller.svelte.ts
@@ -30,8 +30,8 @@ import {
   type GlobalFormText,
   globalTextFromConfig,
   parseChatIdFromStartParam,
-  type ResolvedChatOverridePayload,
   resolveChatOverridePayload,
+  type ResolvedChatOverridePayload,
   type UsageWindowStatus,
 } from "./model";
 

--- a/widget/src/lib/config/model.ts
+++ b/widget/src/lib/config/model.ts
@@ -744,7 +744,7 @@ export function fromUnknownGlobal(payload: unknown): UserConfigPayload {
   };
 }
 
-export function fromUnknownChatOverride(
+export function resolveChatOverridePayload(
   payload: unknown,
   global: UserConfigPayload,
 ): ResolvedChatOverridePayload {
@@ -781,6 +781,8 @@ export function fromUnknownChatOverride(
     ),
   };
 }
+
+export const fromUnknownChatOverride = resolveChatOverridePayload;
 
 export function fromUnknownCurrentCharacter(
   payload: unknown,
@@ -922,223 +924,13 @@ export function buildGlobalPayload(
     blacklistedReactions: textareaToStringList(text.blacklistedReactions),
     ai: {
       ...config.ai,
-      reservedMessageTokens: textareaToStringList(text.reservedMessageTokens),
+      reservedMessageTokens: textareaToStringList(
+        text.reservedMessageTokens,
+      ),
     },
     nepons: textareaToStringList(text.nepons),
     adminIds: textareaToNumberList(text.adminIds),
     trustedIds: textareaToNumberList(text.trustedIds),
     availableModels: textareaToStringList(text.availableModels),
   };
-}
-
-function equalMatcherList(a: Matcher[], b: Matcher[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((item, index) =>
-    matcherToLine(item) === matcherToLine(b[index])
-  );
-}
-
-function equalStringList(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((item, index) => item === b[index]);
-}
-
-export function buildChatPayload(
-  config: ResolvedChatOverridePayload,
-  text: ChatFormText,
-  base: ResolvedChatOverridePayload,
-): ChatOverridePayload {
-  const names = matcherTextareaToList(text.names);
-  const tendToReply = matcherTextareaToList(text.tendToReply);
-  const tendToIgnore = matcherTextareaToList(text.tendToIgnore);
-  const blacklistedReactions = textareaToStringList(
-    text.blacklistedReactions,
-  );
-  const nepons = textareaToStringList(text.nepons);
-
-  const payload: ChatOverridePayload = {};
-  if (!equalMatcherList(names, base.names)) payload.names = names;
-  if (!equalMatcherList(tendToReply, base.tendToReply)) {
-    payload.tendToReply = tendToReply;
-  }
-  if (!equalMatcherList(tendToIgnore, base.tendToIgnore)) {
-    payload.tendToIgnore = tendToIgnore;
-  }
-  if (!equalStringList(blacklistedReactions, base.blacklistedReactions)) {
-    payload.blacklistedReactions = blacklistedReactions;
-  }
-  if (!equalStringList(nepons, base.nepons)) payload.nepons = nepons;
-  if (config.tendToReplyProbability !== base.tendToReplyProbability) {
-    payload.tendToReplyProbability = config.tendToReplyProbability;
-  }
-  if (config.tendToIgnoreProbability !== base.tendToIgnoreProbability) {
-    payload.tendToIgnoreProbability = config.tendToIgnoreProbability;
-  }
-  if (config.randomReplyProbability !== base.randomReplyProbability) {
-    payload.randomReplyProbability = config.randomReplyProbability;
-  }
-  if (config.responseDelay !== base.responseDelay) {
-    payload.responseDelay = config.responseDelay;
-  }
-
-  const requestWindowPerChat: RequestWindowPerChatOverride = {};
-  if (
-    config.requestWindowPerChat.free.maxRequests !==
-      base.requestWindowPerChat.free.maxRequests ||
-    config.requestWindowPerChat.free.windowMinutes !==
-      base.requestWindowPerChat.free.windowMinutes
-  ) {
-    requestWindowPerChat.free = {
-      maxRequests: config.requestWindowPerChat.free.maxRequests,
-      windowMinutes: config.requestWindowPerChat.free.windowMinutes,
-    };
-  }
-  if (
-    config.requestWindowPerChat.trusted.maxRequests !==
-      base.requestWindowPerChat.trusted.maxRequests ||
-    config.requestWindowPerChat.trusted.windowMinutes !==
-      base.requestWindowPerChat.trusted.windowMinutes
-  ) {
-    requestWindowPerChat.trusted = {
-      maxRequests: config.requestWindowPerChat.trusted.maxRequests,
-      windowMinutes: config.requestWindowPerChat.trusted.windowMinutes,
-    };
-  }
-  if (Object.keys(requestWindowPerChat).length > 0) {
-    payload.requestWindowPerChat = requestWindowPerChat;
-  }
-
-  const aiPayload: Partial<ChatEditableAiPayload> = {};
-  if (config.ai.model !== base.ai.model) aiPayload.model = config.ai.model;
-  if (config.ai.temperature !== base.ai.temperature) {
-    aiPayload.temperature = config.ai.temperature;
-  }
-  if (config.ai.topK !== base.ai.topK) aiPayload.topK = config.ai.topK;
-  if (config.ai.topP !== base.ai.topP) aiPayload.topP = config.ai.topP;
-  if ((config.ai.prompt ?? "") !== (base.ai.prompt ?? "")) {
-    aiPayload.prompt = config.ai.prompt;
-  }
-  if ((config.ai.dumbPrompt ?? "") !== (base.ai.dumbPrompt ?? "")) {
-    aiPayload.dumbPrompt = config.ai.dumbPrompt;
-  }
-  if (
-    (config.ai.privateChatPromptAddition ?? "") !==
-      (base.ai.privateChatPromptAddition ?? "")
-  ) {
-    aiPayload.privateChatPromptAddition = config.ai.privateChatPromptAddition;
-  }
-  if (
-    (config.ai.groupChatPromptAddition ?? "") !==
-      (base.ai.groupChatPromptAddition ?? "")
-  ) {
-    aiPayload.groupChatPromptAddition = config.ai.groupChatPromptAddition;
-  }
-  if (
-    (config.ai.commentsPromptAddition ?? "") !==
-      (base.ai.commentsPromptAddition ?? "")
-  ) {
-    aiPayload.commentsPromptAddition = config.ai.commentsPromptAddition;
-  }
-  if ((config.ai.hateModePrompt ?? "") !== (base.ai.hateModePrompt ?? "")) {
-    aiPayload.hateModePrompt = config.ai.hateModePrompt;
-  }
-  if ((config.ai.replyMethod ?? "") !== (base.ai.replyMethod ?? "")) {
-    aiPayload.replyMethod = config.ai.replyMethod;
-  }
-  if ((config.ai.historyVersion ?? "v2") !== (base.ai.historyVersion ?? "v2")) {
-    aiPayload.historyVersion = config.ai.historyVersion;
-  }
-  if (config.ai.messagesToPass !== base.ai.messagesToPass) {
-    aiPayload.messagesToPass = config.ai.messagesToPass;
-  }
-  if (config.ai.messageMaxLength !== base.ai.messageMaxLength) {
-    aiPayload.messageMaxLength = config.ai.messageMaxLength;
-  }
-  if (
-    config.ai.includeAttachmentsInHistory !==
-      base.ai.includeAttachmentsInHistory
-  ) {
-    aiPayload.includeAttachmentsInHistory =
-      config.ai.includeAttachmentsInHistory;
-  }
-  if (config.ai.bytesLimit !== base.ai.bytesLimit) {
-    aiPayload.bytesLimit = config.ai.bytesLimit;
-  }
-
-  if (Object.keys(aiPayload).length > 0) {
-    payload.ai = aiPayload;
-  }
-
-  return payload;
-}
-
-export function collectChatOverridePaths(
-  payload: ChatOverridePayload,
-): string[] {
-  const paths: string[] = [];
-
-  if (payload.names) paths.push("names");
-  if (payload.tendToReply) paths.push("tendToReply");
-  if (payload.tendToReplyProbability !== undefined) {
-    paths.push("tendToReplyProbability");
-  }
-  if (payload.tendToIgnore) paths.push("tendToIgnore");
-  if (payload.tendToIgnoreProbability !== undefined) {
-    paths.push("tendToIgnoreProbability");
-  }
-  if (payload.randomReplyProbability !== undefined) {
-    paths.push("randomReplyProbability");
-  }
-  if (payload.blacklistedReactions) paths.push("blacklistedReactions");
-  if (payload.nepons) paths.push("nepons");
-  if (payload.responseDelay !== undefined) paths.push("responseDelay");
-  if (payload.requestWindowPerChat?.free?.maxRequests !== undefined) {
-    paths.push("requestWindowPerChat.free.maxRequests");
-  }
-  if (payload.requestWindowPerChat?.free?.windowMinutes !== undefined) {
-    paths.push("requestWindowPerChat.free.windowMinutes");
-  }
-  if (payload.requestWindowPerChat?.trusted?.maxRequests !== undefined) {
-    paths.push("requestWindowPerChat.trusted.maxRequests");
-  }
-  if (payload.requestWindowPerChat?.trusted?.windowMinutes !== undefined) {
-    paths.push("requestWindowPerChat.trusted.windowMinutes");
-  }
-
-  if (!payload.ai) {
-    return paths;
-  }
-
-  if (payload.ai.model !== undefined) paths.push("ai.model");
-  if (payload.ai.temperature !== undefined) paths.push("ai.temperature");
-  if (payload.ai.topK !== undefined) paths.push("ai.topK");
-  if (payload.ai.topP !== undefined) paths.push("ai.topP");
-  if (payload.ai.prompt !== undefined) paths.push("ai.prompt");
-  if (payload.ai.dumbPrompt !== undefined) paths.push("ai.dumbPrompt");
-  if (payload.ai.privateChatPromptAddition !== undefined) {
-    paths.push("ai.privateChatPromptAddition");
-  }
-  if (payload.ai.groupChatPromptAddition !== undefined) {
-    paths.push("ai.groupChatPromptAddition");
-  }
-  if (payload.ai.commentsPromptAddition !== undefined) {
-    paths.push("ai.commentsPromptAddition");
-  }
-  if (payload.ai.hateModePrompt !== undefined) {
-    paths.push("ai.hateModePrompt");
-  }
-  if (payload.ai.replyMethod !== undefined) paths.push("ai.replyMethod");
-  if (payload.ai.historyVersion !== undefined) paths.push("ai.historyVersion");
-  if (payload.ai.messagesToPass !== undefined) {
-    paths.push("ai.messagesToPass");
-  }
-  if (payload.ai.messageMaxLength !== undefined) {
-    paths.push("ai.messageMaxLength");
-  }
-  if (payload.ai.includeAttachmentsInHistory !== undefined) {
-    paths.push("ai.includeAttachmentsInHistory");
-  }
-  if (payload.ai.bytesLimit !== undefined) paths.push("ai.bytesLimit");
-
-  return paths;
 }

--- a/widget/src/lib/config/override.ts
+++ b/widget/src/lib/config/override.ts
@@ -1,0 +1,219 @@
+import {
+  type ChatFormText,
+  type ChatOverridePayload,
+  type Matcher,
+  matcherListToTextarea,
+  matcherTextareaToList,
+  matcherToLine,
+  type ResolvedChatOverridePayload,
+  stringListToTextarea,
+  textareaToStringList,
+} from "./model";
+
+export type ChatOverridePath =
+  | "names"
+  | "tendToReply"
+  | "tendToReplyProbability"
+  | "tendToIgnore"
+  | "tendToIgnoreProbability"
+  | "randomReplyProbability"
+  | "blacklistedReactions"
+  | "nepons"
+  | "responseDelay"
+  | "requestWindowPerChat.free.maxRequests"
+  | "requestWindowPerChat.free.windowMinutes"
+  | "requestWindowPerChat.trusted.maxRequests"
+  | "requestWindowPerChat.trusted.windowMinutes"
+  | "ai.model"
+  | "ai.temperature"
+  | "ai.topK"
+  | "ai.topP"
+  | "ai.prompt"
+  | "ai.dumbPrompt"
+  | "ai.privateChatPromptAddition"
+  | "ai.groupChatPromptAddition"
+  | "ai.commentsPromptAddition"
+  | "ai.hateModePrompt"
+  | "ai.replyMethod"
+  | "ai.historyVersion"
+  | "ai.messagesToPass"
+  | "ai.messageMaxLength"
+  | "ai.includeAttachmentsInHistory"
+  | "ai.bytesLimit";
+
+type TextKey = keyof ChatFormText;
+
+interface ChatOverrideField {
+  path: ChatOverridePath;
+  textKey?: TextKey;
+  textKind?: "matcherList" | "stringList";
+  fallback?: unknown;
+}
+
+export const CHAT_OVERRIDE_FIELDS: readonly ChatOverrideField[] = [
+  { path: "tendToReplyProbability" },
+  { path: "tendToIgnoreProbability" },
+  { path: "randomReplyProbability" },
+  { path: "responseDelay" },
+  { path: "ai.historyVersion", fallback: "v2" },
+  { path: "names", textKey: "names", textKind: "matcherList" },
+  { path: "tendToReply", textKey: "tendToReply", textKind: "matcherList" },
+  { path: "tendToIgnore", textKey: "tendToIgnore", textKind: "matcherList" },
+  {
+    path: "blacklistedReactions",
+    textKey: "blacklistedReactions",
+    textKind: "stringList",
+  },
+  { path: "nepons", textKey: "nepons", textKind: "stringList" },
+  { path: "ai.model" },
+  { path: "ai.temperature" },
+  { path: "ai.topK" },
+  { path: "ai.topP" },
+  { path: "ai.prompt", fallback: "" },
+  { path: "ai.dumbPrompt", fallback: "" },
+  { path: "ai.privateChatPromptAddition", fallback: "" },
+  { path: "ai.groupChatPromptAddition", fallback: "" },
+  { path: "ai.commentsPromptAddition", fallback: "" },
+  { path: "ai.hateModePrompt", fallback: "" },
+  { path: "ai.messagesToPass" },
+  { path: "ai.messageMaxLength" },
+  { path: "ai.bytesLimit" },
+  { path: "ai.replyMethod", fallback: "" },
+  { path: "ai.includeAttachmentsInHistory" },
+  { path: "requestWindowPerChat.free.maxRequests" },
+  { path: "requestWindowPerChat.free.windowMinutes" },
+  { path: "requestWindowPerChat.trusted.maxRequests" },
+  { path: "requestWindowPerChat.trusted.windowMinutes" },
+] as const;
+
+function getPath(source: unknown, path: ChatOverridePath): unknown {
+  let current = source;
+  for (const part of path.split(".")) {
+    if (!current || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function setPath(
+  target: Record<string, unknown>,
+  path: ChatOverridePath,
+  value: unknown,
+): void {
+  const parts = path.split(".");
+  let current = target;
+  for (const part of parts.slice(0, -1)) {
+    const existing = current[part];
+    if (
+      !existing || typeof existing !== "object" || Array.isArray(existing)
+    ) {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (isMatcherList(a) && isMatcherList(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((item, index) =>
+      matcherToLine(item) === matcherToLine(b[index])
+    );
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((item, index) => valuesEqual(item, b[index]));
+  }
+
+  return a === b;
+}
+
+function isMatcherList(value: unknown): value is Matcher[] {
+  return Array.isArray(value) &&
+    value.every((item) =>
+      typeof item === "string" ||
+      Boolean(item && typeof item === "object" && "__regex" in item)
+    );
+}
+
+function valueForComparison(value: unknown, fallback: unknown): unknown {
+  return value ?? fallback;
+}
+
+function readEditedValue(
+  field: ChatOverrideField,
+  config: ResolvedChatOverridePayload,
+  text: ChatFormText,
+): unknown {
+  if (!field.textKey) return getPath(config, field.path);
+
+  if (field.textKind === "matcherList") {
+    return matcherTextareaToList(text[field.textKey]);
+  }
+
+  return textareaToStringList(text[field.textKey]);
+}
+
+function readBaseValue(
+  field: ChatOverrideField,
+  base: ResolvedChatOverridePayload,
+): unknown {
+  return getPath(base, field.path);
+}
+
+export function buildChatPayload(
+  config: ResolvedChatOverridePayload,
+  text: ChatFormText,
+  base: ResolvedChatOverridePayload,
+): ChatOverridePayload {
+  const payload: Record<string, unknown> = {};
+
+  for (const field of CHAT_OVERRIDE_FIELDS) {
+    const edited = readEditedValue(field, config, text);
+    const inherited = readBaseValue(field, base);
+    if (
+      !valuesEqual(
+        valueForComparison(edited, field.fallback),
+        valueForComparison(inherited, field.fallback),
+      )
+    ) {
+      setPath(payload, field.path, edited);
+    }
+  }
+
+  // Path metadata builds only ChatOverridePayload keys, but TS cannot infer it.
+  return payload as ChatOverridePayload;
+}
+
+export function collectChatOverridePaths(
+  payload: ChatOverridePayload,
+): ChatOverridePath[] {
+  return CHAT_OVERRIDE_FIELDS
+    .map((field) => field.path)
+    .filter((path) => getPath(payload, path) !== undefined);
+}
+
+export function resetChatOverridePath(
+  path: ChatOverridePath,
+  config: ResolvedChatOverridePayload,
+  text: ChatFormText,
+  base: ResolvedChatOverridePayload,
+): void {
+  const field = CHAT_OVERRIDE_FIELDS.find((item) => item.path === path);
+  if (!field) return;
+
+  const inherited = readBaseValue(field, base);
+  // ResolvedChatOverridePayload is mutable form state; setPath needs an indexable view.
+  setPath(config as unknown as Record<string, unknown>, path, inherited);
+
+  if (!field.textKey) return;
+
+  if (field.textKind === "matcherList") {
+    text[field.textKey] = matcherListToTextarea(inherited as Matcher[]);
+    return;
+  }
+
+  text[field.textKey] = stringListToTextarea(inherited as string[]);
+}

--- a/widget/src/lib/config/override.ts
+++ b/widget/src/lib/config/override.ts
@@ -1,4 +1,8 @@
 import {
+  chatOverrideContract,
+  type ChatOverridePath,
+} from "../../../../lib/config-contract";
+import {
   type ChatFormText,
   type ChatOverridePayload,
   type Matcher,
@@ -10,36 +14,7 @@ import {
   textareaToStringList,
 } from "./model";
 
-export type ChatOverridePath =
-  | "names"
-  | "tendToReply"
-  | "tendToReplyProbability"
-  | "tendToIgnore"
-  | "tendToIgnoreProbability"
-  | "randomReplyProbability"
-  | "blacklistedReactions"
-  | "nepons"
-  | "responseDelay"
-  | "requestWindowPerChat.free.maxRequests"
-  | "requestWindowPerChat.free.windowMinutes"
-  | "requestWindowPerChat.trusted.maxRequests"
-  | "requestWindowPerChat.trusted.windowMinutes"
-  | "ai.model"
-  | "ai.temperature"
-  | "ai.topK"
-  | "ai.topP"
-  | "ai.prompt"
-  | "ai.dumbPrompt"
-  | "ai.privateChatPromptAddition"
-  | "ai.groupChatPromptAddition"
-  | "ai.commentsPromptAddition"
-  | "ai.hateModePrompt"
-  | "ai.replyMethod"
-  | "ai.historyVersion"
-  | "ai.messagesToPass"
-  | "ai.messageMaxLength"
-  | "ai.includeAttachmentsInHistory"
-  | "ai.bytesLimit";
+export type { ChatOverridePath };
 
 type TextKey = keyof ChatFormText;
 
@@ -50,40 +25,37 @@ interface ChatOverrideField {
   fallback?: unknown;
 }
 
-export const CHAT_OVERRIDE_FIELDS: readonly ChatOverrideField[] = [
-  { path: "tendToReplyProbability" },
-  { path: "tendToIgnoreProbability" },
-  { path: "randomReplyProbability" },
-  { path: "responseDelay" },
-  { path: "ai.historyVersion", fallback: "v2" },
-  { path: "names", textKey: "names", textKind: "matcherList" },
-  { path: "tendToReply", textKey: "tendToReply", textKind: "matcherList" },
-  { path: "tendToIgnore", textKey: "tendToIgnore", textKind: "matcherList" },
-  {
-    path: "blacklistedReactions",
+const widgetFieldMeta: Partial<
+  Record<ChatOverridePath, Omit<ChatOverrideField, "path">>
+> = {
+  names: { textKey: "names", textKind: "matcherList" },
+  tendToReply: { textKey: "tendToReply", textKind: "matcherList" },
+  tendToIgnore: { textKey: "tendToIgnore", textKind: "matcherList" },
+  blacklistedReactions: {
     textKey: "blacklistedReactions",
     textKind: "stringList",
   },
-  { path: "nepons", textKey: "nepons", textKind: "stringList" },
-  { path: "ai.model" },
-  { path: "ai.temperature" },
-  { path: "ai.topK" },
-  { path: "ai.topP" },
-  { path: "ai.prompt", fallback: "" },
-  { path: "ai.dumbPrompt", fallback: "" },
-  { path: "ai.privateChatPromptAddition", fallback: "" },
-  { path: "ai.groupChatPromptAddition", fallback: "" },
-  { path: "ai.commentsPromptAddition", fallback: "" },
-  { path: "ai.hateModePrompt", fallback: "" },
-  { path: "ai.messagesToPass" },
-  { path: "ai.messageMaxLength" },
-  { path: "ai.bytesLimit" },
-  { path: "ai.replyMethod", fallback: "" },
-  { path: "ai.includeAttachmentsInHistory" },
-  { path: "requestWindowPerChat.free.maxRequests" },
-  { path: "requestWindowPerChat.free.windowMinutes" },
-  { path: "requestWindowPerChat.trusted.maxRequests" },
-  { path: "requestWindowPerChat.trusted.windowMinutes" },
+  nepons: { textKey: "nepons", textKind: "stringList" },
+  "ai.historyVersion": { fallback: "v2" },
+  "ai.prompt": { fallback: "" },
+  "ai.dumbPrompt": { fallback: "" },
+  "ai.privateChatPromptAddition": { fallback: "" },
+  "ai.groupChatPromptAddition": { fallback: "" },
+  "ai.commentsPromptAddition": { fallback: "" },
+  "ai.hateModePrompt": { fallback: "" },
+  "ai.replyMethod": { fallback: "" },
+};
+
+function buildField(path: ChatOverridePath): ChatOverrideField {
+  return { path, ...widgetFieldMeta[path] };
+}
+
+export const CHAT_OVERRIDE_FIELDS: readonly ChatOverrideField[] = [
+  ...chatOverrideContract.regularDelta.map(buildField),
+  ...chatOverrideContract.regularDirect.map(buildField),
+  ...chatOverrideContract.trustedAi
+    .map((key) => buildField(`ai.${key}` as ChatOverridePath)),
+  ...chatOverrideContract.adminWindow.map(buildField),
 ] as const;
 
 function getPath(source: unknown, path: ChatOverridePath): unknown {

--- a/widget/src/vite-env.d.ts
+++ b/widget/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- centralize widget chat override field metadata for diffing, path collection, and inherited-value resets
- simplify backend config policy projection and sanitization with shared field lists
- move chat base projection out of the bootstrap handler and add Vite env types for widget checks

## Verification
- deno check --allow-import main.ts
- deno lint
- AI_TOKEN="test" deno test -A
- deno task check (widget)
- deno task lint (widget)
- deno task build (widget)