### PR TITLE
Add model generation capabilities

### DIFF
--- a/.beans/slusha-5tx4--introduce-model-provider-capabilities-and-structur.md
+++ b/.beans/slusha-5tx4--introduce-model-provider-capabilities-and-structur.md
@@ -1,0 +1,20 @@
+---
+# slusha-5tx4
+title: Introduce model provider capabilities and structured generation adapter
+status: completed
+type: task
+priority: normal
+created_at: 2026-07-11T18:27:29Z
+updated_at: 2026-07-11T18:32:53Z
+---
+
+Implement the provider/model abstraction proposed in session ses_0b2706eaeffeshvI2pCC4iLJpr.
+
+- [x] Inspect current generation, history, and character boundaries
+- [x] Add resolved model capabilities and remove caller provider checks
+- [x] Extract reusable structured output transport handling
+- [x] Run focused verification and record outcome
+
+
+
+Verification: `deno check` and `deno lint` passed for the changed modules; `deno test --allow-all` passed (32 tests).

--- a/lib/ai/generation-policy.ts
+++ b/lib/ai/generation-policy.ts
@@ -5,6 +5,7 @@ import { UserConfig } from '../config.ts';
 import { ModelProvider, parseModelRef } from './model-ref.ts';
 
 export type GenerationTask = 'chat' | 'character';
+export type StructuredOutputMode = 'tool' | 'json-text';
 
 const OPENCODE_BASE_URL = 'https://opencode.ai/zen/go/v1';
 
@@ -25,7 +26,18 @@ export interface ResolvedGenerationPolicy {
     provider: ModelProvider;
     providerOptions?: ProviderOptions;
     maxOutputTokens?: number;
+    capabilities: ModelCapabilities;
     telemetry: GenerationPolicyTelemetry;
+}
+
+/**
+ * Model behavior that generation callers need to adapt to. Keep this limited
+ * to actual compatibility differences; Telegram and prompt policy stay in
+ * their respective layers.
+ */
+export interface ModelCapabilities {
+    binaryHistoryAttachments: boolean;
+    structuredOutputMode: StructuredOutputMode;
 }
 
 interface GenerationPolicyInput {
@@ -40,6 +52,53 @@ interface GenerationPolicyInput {
 type ProviderOptions = NonNullable<
     Parameters<typeof generateText>[0]['providerOptions']
 >;
+
+const providerCapabilities: Record<ModelProvider, ModelCapabilities> = {
+    google: {
+        binaryHistoryAttachments: true,
+        structuredOutputMode: 'tool',
+    },
+    openrouter: {
+        binaryHistoryAttachments: false,
+        structuredOutputMode: 'tool',
+    },
+    opencode: {
+        binaryHistoryAttachments: false,
+        structuredOutputMode: 'tool',
+    },
+};
+
+interface ModelCapabilityRule {
+    matches(modelId: string): boolean;
+    capabilities: Partial<ModelCapabilities>;
+}
+
+const providerModelCapabilityRules: Partial<
+    Record<ModelProvider, ModelCapabilityRule[]>
+> = {
+    opencode: [
+        {
+            matches: (modelId) => modelId.startsWith('deepseek-v4'),
+            capabilities: { structuredOutputMode: 'json-text' },
+        },
+    ],
+};
+
+export function resolveModelCapabilities(
+    provider: ModelProvider,
+    modelId: string,
+): ModelCapabilities {
+    const capabilities = { ...providerCapabilities[provider] };
+    const rules = providerModelCapabilityRules[provider] ?? [];
+
+    for (const rule of rules) {
+        if (rule.matches(modelId)) {
+            Object.assign(capabilities, rule.capabilities);
+        }
+    }
+
+    return capabilities;
+}
 
 function buildGoogleOptions(
     config: UserConfig['ai'],
@@ -136,13 +195,9 @@ function createOpencodeModel(
     return opencodeProvider.chatModel(modelId);
 }
 
-export function resolveGenerationPolicy(input: GenerationPolicyInput): {
-    model: LanguageModel;
-    provider: ModelProvider;
-    providerOptions?: ProviderOptions;
-    maxOutputTokens?: number;
-    telemetry: GenerationPolicyTelemetry;
-} {
+export function resolveGenerationPolicy(
+    input: GenerationPolicyInput,
+): ResolvedGenerationPolicy {
     const parsed = parseModelRef(input.modelRef);
     const taskConfig = input.config.generation[input.task];
 
@@ -174,6 +229,10 @@ export function resolveGenerationPolicy(input: GenerationPolicyInput): {
                 ? providerOptions
                 : undefined,
             maxOutputTokens: taskConfig.maxOutputTokens,
+            capabilities: resolveModelCapabilities(
+                parsed.provider,
+                parsed.modelId,
+            ),
             telemetry,
         };
     }
@@ -187,6 +246,10 @@ export function resolveGenerationPolicy(input: GenerationPolicyInput): {
             model: createOpencodeModel(parsed.modelId, input.opencodeToken),
             provider: parsed.provider,
             maxOutputTokens: taskConfig.maxOutputTokens,
+            capabilities: resolveModelCapabilities(
+                parsed.provider,
+                parsed.modelId,
+            ),
             telemetry: {
                 provider: parsed.provider,
                 modelRef: parsed.raw,
@@ -222,6 +285,10 @@ export function resolveGenerationPolicy(input: GenerationPolicyInput): {
             ? providerOptions
             : undefined,
         maxOutputTokens: taskConfig.maxOutputTokens,
+        capabilities: resolveModelCapabilities(
+            parsed.provider,
+            parsed.modelId,
+        ),
         telemetry,
     };
 }

--- a/lib/ai/generation-policy_test.ts
+++ b/lib/ai/generation-policy_test.ts
@@ -1,0 +1,27 @@
+import { assertEquals } from '@std/assert';
+import { resolveModelCapabilities } from './generation-policy.ts';
+
+Deno.test('resolveModelCapabilities applies provider defaults', () => {
+    assertEquals(resolveModelCapabilities('google', 'gemini-2.5-flash'), {
+        binaryHistoryAttachments: true,
+        structuredOutputMode: 'tool',
+    });
+    assertEquals(
+        resolveModelCapabilities('openrouter', 'google/gemini-2.5-flash'),
+        {
+            binaryHistoryAttachments: false,
+            structuredOutputMode: 'tool',
+        },
+    );
+});
+
+Deno.test('resolveModelCapabilities applies opencode model rules', () => {
+    assertEquals(resolveModelCapabilities('opencode', 'deepseek-v4-flash'), {
+        binaryHistoryAttachments: false,
+        structuredOutputMode: 'json-text',
+    });
+    assertEquals(resolveModelCapabilities('opencode', 'kimi-k2.5'), {
+        binaryHistoryAttachments: false,
+        structuredOutputMode: 'tool',
+    });
+});

--- a/lib/ai/structured-generation.ts
+++ b/lib/ai/structured-generation.ts
@@ -1,0 +1,105 @@
+import { generateText, hasToolCall, type ModelMessage, type Tool } from 'ai';
+import type { ResolvedGenerationPolicy } from './generation-policy.ts';
+import { parseStructuredJsonText } from './structured-json.ts';
+
+export type StructuredGenerationPrompt =
+    | {
+        kind: 'messages';
+        instructions: string;
+        messages: ModelMessage[];
+    }
+    | {
+        kind: 'prompt';
+        prompt: string;
+    };
+
+interface StructuredGenerationTool<T> {
+    definition: Tool;
+    name: string;
+    parse(input: unknown): T | undefined;
+}
+
+interface StructuredGenerationJson<T> {
+    instruction: string;
+    parse(value: unknown): T | undefined;
+}
+
+export interface StructuredGenerationInput<T> {
+    policy: ResolvedGenerationPolicy;
+    prompt: StructuredGenerationPrompt;
+    temperature?: number;
+    topK?: number;
+    topP?: number;
+    maxRetries?: number;
+    tool: StructuredGenerationTool<T>;
+    json: StructuredGenerationJson<T>;
+    telemetry: {
+        toolFunctionId: string;
+        jsonFunctionId: string;
+    };
+}
+
+export async function generateStructuredOutput<T>(
+    input: StructuredGenerationInput<T>,
+): Promise<T> {
+    const settings = {
+        model: input.policy.model,
+        providerOptions: input.policy.providerOptions,
+        temperature: input.temperature,
+        topK: input.topK,
+        topP: input.topP,
+        maxOutputTokens: input.policy.maxOutputTokens,
+        maxRetries: input.maxRetries,
+    };
+
+    if (input.policy.capabilities.structuredOutputMode === 'json-text') {
+        const result = input.prompt.kind === 'messages'
+            ? await generateText({
+                ...settings,
+                instructions: input.prompt.instructions,
+                messages: [
+                    ...input.prompt.messages,
+                    { role: 'user', content: input.json.instruction },
+                ],
+                telemetry: { functionId: input.telemetry.jsonFunctionId },
+            })
+            : await generateText({
+                ...settings,
+                prompt: `${input.prompt.prompt} ${input.json.instruction}`,
+                telemetry: { functionId: input.telemetry.jsonFunctionId },
+            });
+
+        const output = parseStructuredJsonText(result.text, input.json.parse);
+        if (output !== undefined) return output;
+
+        throw new Error('Structured JSON output invalid');
+    }
+
+    const tools = { [input.tool.name]: input.tool.definition };
+    const result = input.prompt.kind === 'messages'
+        ? await generateText({
+            ...settings,
+            tools,
+            toolChoice: { type: 'tool', toolName: input.tool.name },
+            stopWhen: hasToolCall(input.tool.name),
+            instructions: input.prompt.instructions,
+            messages: input.prompt.messages,
+            telemetry: { functionId: input.telemetry.toolFunctionId },
+        })
+        : await generateText({
+            ...settings,
+            tools,
+            toolChoice: { type: 'tool', toolName: input.tool.name },
+            stopWhen: hasToolCall(input.tool.name),
+            prompt: input.prompt.prompt,
+            telemetry: { functionId: input.telemetry.toolFunctionId },
+        });
+
+    const toolCall = result.toolCalls.find((call) =>
+        call.toolName === input.tool.name
+    );
+    const output = toolCall ? input.tool.parse(toolCall.input) : undefined;
+    if (output !== undefined) return output;
+
+    throw new Error('Structured tool call missing or invalid after retries');
+}

--- a/lib/ai/structured-generation_test.ts
+++ b/lib/ai/structured-generation_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from '@std/assert';
+import { parseStructuredJsonText } from './structured-json.ts';
+
+function parseStrings(value: unknown): string[] | undefined {
+    if (
+        Array.isArray(value) &&
+        value.every((entry) => typeof entry === 'string')
+    ) {
+        return value;
+    }
+
+    return undefined;
+}
+
+Deno.test('parseStructuredJsonText recovers plain, fenced, and embedded JSON', () => {
+    assertEquals(parseStructuredJsonText('["one", "two"]', parseStrings), [
+        'one',
+        'two',
+    ]);
+    assertEquals(
+        parseStructuredJsonText('```json\n["one", "two"]\n```', parseStrings),
+        ['one', 'two'],
+    );
+    assertEquals(
+        parseStructuredJsonText('Result: ["one", "two"] Done.', parseStrings),
+        ['one', 'two'],
+    );
+});

--- a/lib/ai/structured-json.ts
+++ b/lib/ai/structured-json.ts
@@ -1,0 +1,40 @@
+/**
+ * Recovers JSON text without coupling the transport layer to a domain schema.
+ * Callers own schema validation through the parse callback.
+ */
+export function parseStructuredJsonText<T>(
+    text: string,
+    parse: (value: unknown) => T | undefined,
+): T | undefined {
+    const trimmed = text.trim();
+    if (!trimmed) return undefined;
+
+    const candidates = [trimmed];
+    const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+    if (fenced?.[1]) {
+        candidates.push(fenced[1].trim());
+    }
+
+    const arrayStart = trimmed.indexOf('[');
+    const arrayEnd = trimmed.lastIndexOf(']');
+    if (arrayStart >= 0 && arrayEnd > arrayStart) {
+        candidates.push(trimmed.slice(arrayStart, arrayEnd + 1));
+    }
+
+    const objectStart = trimmed.indexOf('{');
+    const objectEnd = trimmed.lastIndexOf('}');
+    if (objectStart >= 0 && objectEnd > objectStart) {
+        candidates.push(trimmed.slice(objectStart, objectEnd + 1));
+    }
+
+    for (const candidate of candidates) {
+        try {
+            const output = parse(JSON.parse(candidate));
+            if (output !== undefined) return output;
+        } catch {
+            // Try the next common JSON wrapping style.
+        }
+    }
+
+    return undefined;
+}

--- a/lib/telegram/bot/character.ts
+++ b/lib/telegram/bot/character.ts
@@ -9,7 +9,7 @@ import { getCharacter, getCharacters, pageSize } from '../../charhub/api.ts';
 import { sliceMessage } from '../../helpers.ts';
 import logger from '../../logger.ts';
 import { InlineQueryResultArticle } from 'grammy_types';
-import { generateText, hasToolCall, tool } from 'ai';
+import { tool } from 'ai';
 import z from 'zod';
 import { limit } from 'grammy_ratelimiter';
 import DOMPurify from 'isomorphic-dompurify';
@@ -17,6 +17,7 @@ import remarkHtml from 'remark-html';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 import { resolveGenerationPolicy } from '../../ai/generation-policy.ts';
+import { generateStructuredOutput } from '../../ai/structured-generation.ts';
 import { CharacterRepository } from '../../persistence/characters.ts';
 import { MessageRepository } from '../../persistence/messages.ts';
 
@@ -28,38 +29,6 @@ const characterNamesTool = tool({
     description: 'Submit generated character name variants.',
     inputSchema: characterNamesInputSchema,
 });
-
-function parseCharacterNamesText(text: string): string[] | undefined {
-    const trimmed = text.trim();
-    if (!trimmed) return undefined;
-
-    const candidates = [trimmed];
-    const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
-    if (fenced?.[1]) {
-        candidates.push(fenced[1].trim());
-    }
-
-    const objectStart = trimmed.indexOf('{');
-    const objectEnd = trimmed.lastIndexOf('}');
-    if (objectStart >= 0 && objectEnd > objectStart) {
-        candidates.push(trimmed.slice(objectStart, objectEnd + 1));
-    }
-
-    for (const candidate of candidates) {
-        try {
-            const parsed = JSON.parse(candidate);
-            const namesObject = characterNamesInputSchema.safeParse(parsed);
-            if (namesObject.success) return namesObject.data.names;
-
-            const namesArray = z.array(z.string()).safeParse(parsed);
-            if (namesArray.success) return namesArray.data;
-        } catch {
-            // Try the next common JSON wrapping style.
-        }
-    }
-
-    return undefined;
-}
 
 const bot = new Composer<SlushaContext>();
 
@@ -469,65 +438,38 @@ bot.callbackQuery(/set.*/, async (ctx) => {
         const prompt =
             `Напиши варианты имени "${character.name}", которые пользователи могут использовать в качестве обращения к этому персонажу. ` +
             'Варианты должны быть на русском, английском, уменьшительно ласкательные и очевидные похожие формы.';
-        const runOpencodeJsonFallback = async (): Promise<string[]> => {
-            const fallback = await generateText({
-                model: generationPolicy.model,
-                temperature: config.temperature,
-                topP: config.topP,
-                maxOutputTokens: generationPolicy.maxOutputTokens,
-                prompt: prompt +
-                    ' Верни только JSON объект вида {"names":["..."]}, без markdown и пояснений.',
-                telemetry: {
-                    functionId: 'character-names-opencode-json-fallback',
+        names = await generateStructuredOutput({
+            policy: generationPolicy,
+            prompt: { kind: 'prompt', prompt },
+            temperature: config.temperature,
+            topK: config.topK,
+            topP: config.topP,
+            tool: {
+                definition: characterNamesTool,
+                name: 'submit_character_names',
+                parse: (value) => {
+                    const parsed = characterNamesInputSchema.safeParse(value);
+                    return parsed.success ? parsed.data.names : undefined;
                 },
-            });
-            const parsedNames = parseCharacterNamesText(fallback.text);
-            if (parsedNames) return parsedNames;
-            throw new Error('Opencode character names JSON fallback invalid');
-        };
+            },
+            json: {
+                instruction:
+                    'Верни только JSON объект вида {"names":["..."]}, без markdown и пояснений.',
+                parse: (value) => {
+                    const namesObject = characterNamesInputSchema.safeParse(
+                        value,
+                    );
+                    if (namesObject.success) return namesObject.data.names;
 
-        let result;
-        if (
-            generationPolicy.provider === 'opencode' &&
-            generationPolicy.telemetry.modelId.startsWith('deepseek-v4')
-        ) {
-            names = await runOpencodeJsonFallback();
-        } else {
-            result = await generateText({
-                model: generationPolicy.model,
-                providerOptions: generationPolicy.providerOptions,
-                temperature: config.temperature,
-                topK: config.topK,
-                topP: config.topP,
-                maxOutputTokens: generationPolicy.maxOutputTokens,
-                tools: {
-                    submit_character_names: characterNamesTool,
+                    const namesArray = z.array(z.string()).safeParse(value);
+                    return namesArray.success ? namesArray.data : undefined;
                 },
-                toolChoice: {
-                    type: 'tool',
-                    toolName: 'submit_character_names',
-                },
-                stopWhen: hasToolCall('submit_character_names'),
-                prompt,
-                telemetry: {
-                    functionId: 'character-names',
-                },
-            });
-        }
-
-        if (names.length === 0) {
-            if (!result) {
-                throw new Error('Character names generation result missing');
-            }
-
-            const toolCall = result.toolCalls.find((call) =>
-                call.toolName === 'submit_character_names'
-            );
-            if (!toolCall) {
-                throw new Error('Character names tool call missing');
-            }
-            names = characterNamesInputSchema.parse(toolCall.input).names;
-        }
+            },
+            telemetry: {
+                toolFunctionId: 'character-names',
+                jsonFunctionId: 'character-names-opencode-json-fallback',
+            },
+        });
     } catch (error) {
         logger.error(error, 'Error getting names for character');
         return await ctx.reply(ctx.t('character-names-error'));

--- a/lib/telegram/handlers/ai.ts
+++ b/lib/telegram/handlers/ai.ts
@@ -1,13 +1,7 @@
 import { Bot, Composer } from 'grammy';
 import { SlushaContext } from '../setup-bot.ts';
 import logger from '../../logger.ts';
-import {
-    APICallError,
-    generateText,
-    hasToolCall,
-    ModelMessage,
-    tool,
-} from 'ai';
+import { APICallError, type ModelMessage, tool } from 'ai';
 import { makeHistory } from '../../history.ts';
 import { getRandomNepon, prettyDate } from '../../helpers.ts';
 import { replyGeneric, replyWithMarkdownId } from '../helpers.ts';
@@ -37,9 +31,9 @@ import {
 } from '../../ai/chat-context.ts';
 import { canonicalizeReaction, resolveEnabledReactions } from '../reactions.ts';
 import { isMissingSendTextRightsError } from '../reply-rights.ts';
-import { parseModelRef } from '../../ai/model-ref.ts';
 import { buildLanguageProtocol } from '../../ai/language-protocol.ts';
 import { resolveGenerationPolicy } from '../../ai/generation-policy.ts';
+import { generateStructuredOutput } from '../../ai/structured-generation.ts';
 
 const DEFAULT_CHAT_ACTIONS_TOOL_DESCRIPTION =
     'Submit Telegram actions once per turn. Return entries where each item is either {"type":"reply","text":"...","target_ref":"tN"} or {"type":"react","react":"❤","target_ref":"tN"}. Use target_ref values from Reply Target Map. If target_ref is omitted, action applies to the triggering message.';
@@ -122,25 +116,6 @@ function createSendChatActionsTool(description: string) {
     });
 }
 
-function parseSendChatActionsEntries(
-    toolCalls: Array<{ toolName: string; input: unknown }>,
-): ChatEntry[] | undefined {
-    const chatActionsToolCall = toolCalls.find((call) =>
-        call.toolName === 'send_chat_actions'
-    );
-    const parsedToolCallInput = chatActionsToolCall
-        ? chatActionsToolInputSchema.safeParse(
-            chatActionsToolCall.input,
-        )
-        : undefined;
-
-    if (parsedToolCallInput?.success) {
-        return parsedToolCallInput.data.entries;
-    }
-
-    return undefined;
-}
-
 function hasReservedMessageToken(entries: ChatEntry[]): boolean {
     return entries.some((entry) => {
         if (!isTextEntry(entry) || typeof entry.text !== 'string') {
@@ -155,35 +130,6 @@ function hasReservedMessageToken(entries: ChatEntry[]): boolean {
 function isReservedMessageTokenError(error: unknown): boolean {
     return error instanceof Error &&
         error.message === RESERVED_MESSAGE_TOKEN_ERROR;
-}
-
-function parseJsonActionsText(text: string): ChatEntry[] | undefined {
-    const trimmed = text.trim();
-    if (!trimmed) return undefined;
-
-    const candidates = [trimmed];
-    const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
-    if (fenced?.[1]) {
-        candidates.push(fenced[1].trim());
-    }
-
-    const arrayStart = trimmed.indexOf('[');
-    const arrayEnd = trimmed.lastIndexOf(']');
-    if (arrayStart >= 0 && arrayEnd > arrayStart) {
-        candidates.push(trimmed.slice(arrayStart, arrayEnd + 1));
-    }
-
-    for (const candidate of candidates) {
-        try {
-            const parsed = JSON.parse(candidate);
-            const entries = parseChatEntriesFromUnknown(parsed);
-            if (entries) return entries;
-        } catch {
-            // Try the next common JSON wrapping style.
-        }
-    }
-
-    return undefined;
 }
 
 type EffectiveConfig = UserConfig;
@@ -206,9 +152,10 @@ async function sendGeneratedOutput(params: {
         effectiveConfig,
         historyById,
     } = params;
-    const chatTopicId = typeof ctx.msg?.message_thread_id === 'number'
-        ? ctx.msg.message_thread_id
-        : undefined;
+    let chatTopicId: number | undefined;
+    if (typeof ctx.msg?.message_thread_id === 'number') {
+        chatTopicId = ctx.msg.message_thread_id;
+    }
 
     function resolveTargetMessageId(targetRef?: string): number | undefined {
         if (targetRef) {
@@ -295,10 +242,13 @@ async function sendGeneratedOutput(params: {
             replyText = '-' + replyText;
         }
 
-        const explicitTargetRef = typeof res.target_ref === 'string' &&
-                res.target_ref.trim().length > 0
-            ? res.target_ref.trim()
-            : undefined;
+        let explicitTargetRef: string | undefined;
+        if (
+            typeof res.target_ref === 'string' &&
+            res.target_ref.trim().length > 0
+        ) {
+            explicitTargetRef = res.target_ref.trim();
+        }
         let msgToReply: number | undefined;
         if (explicitTargetRef) {
             msgToReply = resolveTargetMessageId(explicitTargetRef);
@@ -311,17 +261,21 @@ async function sendGeneratedOutput(params: {
         if (typeof chatTopicId === 'number' && typeof msgToReply === 'number') {
             const targetMsg = historyById.get(msgToReply);
             const targetTopicId = targetMsg?.info.message_thread_id;
-            const targetInSameTopic = targetMsg
-                ? targetTopicId === chatTopicId
-                : msgToReply === ctx.msg?.message_id;
+            let targetInSameTopic: boolean;
+            if (targetMsg) {
+                targetInSameTopic = targetTopicId === chatTopicId;
+            } else {
+                targetInSameTopic = msgToReply === ctx.msg?.message_id;
+            }
             if (!targetInSameTopic) {
                 msgToReply = undefined;
             }
         }
 
-        const replyOther = typeof chatTopicId === 'number'
-            ? { message_thread_id: chatTopicId }
-            : undefined;
+        let replyOther: { message_thread_id: number } | undefined;
+        if (typeof chatTopicId === 'number') {
+            replyOther = { message_thread_id: chatTopicId };
+        }
 
         let replyInfo;
         try {
@@ -373,10 +327,13 @@ async function sendGeneratedOutput(params: {
             threadParentMessageId = replyInfo.reply_to_message.message_id;
             const parent = historyById.get(threadParentMessageId);
             if (parent) {
-                threadId = parent.threadId ??
-                    (typeof parent.threadRootMessageId === 'number'
-                        ? `thread:${parent.threadRootMessageId}`
-                        : `thread:${threadParentMessageId}`);
+                if (parent.threadId) {
+                    threadId = parent.threadId;
+                } else if (typeof parent.threadRootMessageId === 'number') {
+                    threadId = `thread:${parent.threadRootMessageId}`;
+                } else {
+                    threadId = `thread:${threadParentMessageId}`;
+                }
                 threadRootMessageId = parent.threadRootMessageId ?? parent.id;
                 threadSource = 'bot_parent';
             } else {
@@ -417,10 +374,10 @@ async function sendGeneratedOutput(params: {
 
         const typingSpeed = 1200; // symbol per minute
         const next = output[i + 1];
-        const nextLen =
-            next && isTextEntry(next) && typeof next.text === 'string'
-                ? next.text.length
-                : 0;
+        let nextLen = 0;
+        if (next && isTextEntry(next) && typeof next.text === 'string') {
+            nextLen = next.text.length;
+        }
         let msToWait = nextLen / typingSpeed * 60 * 1000;
         if (msToWait > 5000) {
             msToWait = 5000;
@@ -461,10 +418,10 @@ export function createAIMiddleware(bot: Bot<SlushaContext>) {
             Math.max(maxTargetCount, maxAttemptHistoryLimit),
         );
 
-        const activeMessageThreadId = typeof ctx.msg.message_thread_id ===
-                'number'
-            ? ctx.msg.message_thread_id
-            : undefined;
+        let activeMessageThreadId: number | undefined;
+        if (typeof ctx.msg.message_thread_id === 'number') {
+            activeMessageThreadId = ctx.msg.message_thread_id;
+        }
         const targetRefs = buildTargetRefs(savedHistory, maxTargetCount, {
             activeMessageThreadId,
         });
@@ -479,7 +436,6 @@ export function createAIMiddleware(bot: Bot<SlushaContext>) {
         const character = chatState.character;
 
         const modelRef = effectiveConfig.ai.model;
-        const parsedModel = parseModelRef(modelRef);
 
         const time = new Date().getTime();
         const maxGenerationRetries = 2;
@@ -493,9 +449,30 @@ export function createAIMiddleware(bot: Bot<SlushaContext>) {
         }
         const chatName = ctx.chat.first_name ?? ctx.chat.title;
 
-        const activeMembers = ctx.chat.type === 'private'
-            ? []
-            : await ctx.members.getActiveMembers();
+        let activeMembers: Awaited<
+            ReturnType<typeof ctx.members.getActiveMembers>
+        > = [];
+        if (ctx.chat.type !== 'private') {
+            activeMembers = await ctx.members.getActiveMembers();
+        }
+
+        let generationPolicy: ReturnType<typeof resolveGenerationPolicy>;
+        try {
+            generationPolicy = resolveGenerationPolicy({
+                modelRef,
+                config: effectiveConfig.ai,
+                openrouterApiKey: ctx.info.openrouterApiKey,
+                opencodeToken: ctx.info.opencodeToken,
+                task: 'chat',
+                expectsStructuredOutput: true,
+            });
+        } catch (error) {
+            logger.error('Could not resolve generation policy', error);
+            if (!ctx.info.isRandom) {
+                await ctx.reply(getRandomNepon(effectiveConfig));
+            }
+            return;
+        }
 
         const buildGenerationInputForAttempt = async (
             plan: GenerationAttemptPlan,
@@ -551,7 +528,7 @@ export function createAIMiddleware(bot: Bot<SlushaContext>) {
 
             const includeBinaryAttachments =
                 effectiveConfig.ai.includeAttachmentsInHistory &&
-                parsedModel.provider === 'google';
+                generationPolicy.capabilities.binaryHistoryAttachments;
 
             const history = await makeHistory(
                 { token: bot.token, id: bot.botInfo.id },
@@ -588,103 +565,6 @@ export function createAIMiddleware(bot: Bot<SlushaContext>) {
             };
         };
 
-        const generateStructuredActionsOutput = async (
-            input: { instructions: string; messages: ModelMessage[] },
-        ): Promise<ChatEntry[]> => {
-            const generationPolicy = resolveGenerationPolicy({
-                modelRef,
-                config: effectiveConfig.ai,
-                openrouterApiKey: ctx.info.openrouterApiKey,
-                opencodeToken: ctx.info.opencodeToken,
-                task: 'chat',
-                expectsStructuredOutput: true,
-            });
-
-            const runOpencodeJsonFallback = async (): Promise<ChatEntry[]> => {
-                const fallback = await generateText({
-                    model: generationPolicy.model,
-                    temperature: effectiveConfig.ai.temperature,
-                    topP: effectiveConfig.ai.topP,
-                    maxOutputTokens: generationPolicy.maxOutputTokens,
-                    maxRetries: maxGenerationRetries,
-                    instructions: input.instructions,
-                    messages: [
-                        ...input.messages,
-                        {
-                            role: 'user',
-                            content:
-                                'Return only a valid JSON array of actions. Do not use markdown fences or prose.',
-                        },
-                    ],
-                    telemetry: {
-                        functionId: 'user-message-opencode-json-fallback',
-                    },
-                });
-
-                const fallbackEntries = parseJsonActionsText(fallback.text);
-                if (fallbackEntries) {
-                    return fallbackEntries;
-                }
-
-                logger.warn('Opencode JSON fallback output invalid', {
-                    modelRef,
-                    chatId: ctx.chat.id,
-                    finishReason: fallback.finishReason,
-                    usage: fallback.usage,
-                });
-                throw new Error('Opencode JSON fallback output invalid');
-            };
-
-            if (
-                generationPolicy.provider === 'opencode' &&
-                generationPolicy.telemetry.modelId.startsWith('deepseek-v4')
-            ) {
-                return await runOpencodeJsonFallback();
-            }
-
-            const result = await generateText({
-                model: generationPolicy.model,
-                providerOptions: generationPolicy.providerOptions,
-                temperature: effectiveConfig.ai.temperature,
-                topK: effectiveConfig.ai.topK,
-                topP: effectiveConfig.ai.topP,
-                maxOutputTokens: generationPolicy.maxOutputTokens,
-                maxRetries: maxGenerationRetries,
-                tools: {
-                    send_chat_actions: sendChatActionsTool,
-                },
-                toolChoice: {
-                    type: 'tool',
-                    toolName: 'send_chat_actions',
-                },
-                stopWhen: hasToolCall('send_chat_actions'),
-                instructions: input.instructions,
-                messages: input.messages,
-                telemetry: {
-                    functionId: 'user-message',
-                },
-            });
-
-            const entries = parseSendChatActionsEntries(result.toolCalls);
-            if (entries) {
-                return entries;
-            }
-
-            logger.warn(
-                'Structured tool call missing or invalid after retries',
-                {
-                    modelRef,
-                    chatId: ctx.chat.id,
-                    finishReason: result.finishReason,
-                    toolCalls: result.toolCalls.map((call) => call.toolName),
-                    usage: result.usage,
-                },
-            );
-            throw new Error(
-                'Structured tool call missing or invalid after retries',
-            );
-        };
-
         let output: ChatEntry[] | undefined;
         let generationError: unknown;
 
@@ -706,9 +586,46 @@ export function createAIMiddleware(bot: Bot<SlushaContext>) {
             }
 
             try {
-                const generatedOutput = await generateStructuredActionsOutput(
-                    generationInput,
-                );
+                const generatedOutput = await generateStructuredOutput({
+                    policy: generationPolicy,
+                    prompt: {
+                        kind: 'messages',
+                        instructions: generationInput.instructions,
+                        messages: generationInput.messages,
+                    },
+                    temperature: effectiveConfig.ai.temperature,
+                    topK: effectiveConfig.ai.topK,
+                    topP: effectiveConfig.ai.topP,
+                    maxRetries: maxGenerationRetries,
+                    tool: {
+                        definition: sendChatActionsTool,
+                        name: 'send_chat_actions',
+                        parse: (value) => {
+                            const parsed = chatActionsToolInputSchema.safeParse(
+                                value,
+                            );
+                            if (parsed.success) {
+                                return parsed.data.entries;
+                            }
+                            return undefined;
+                        },
+                    },
+                    json: {
+                        instruction:
+                            'Return only a valid JSON array of actions. Do not use markdown fences or prose.',
+                        parse: (value) => {
+                            const entries = parseChatEntriesFromUnknown(value);
+                            if (entries) {
+                                return entries;
+                            }
+                            return undefined;
+                        },
+                    },
+                    telemetry: {
+                        toolFunctionId: 'user-message',
+                        jsonFunctionId: 'user-message-opencode-json-fallback',
+                    },
+                });
                 if (hasReservedMessageToken(generatedOutput)) {
                     throw new Error(RESERVED_MESSAGE_TOKEN_ERROR);
                 }
@@ -753,9 +670,12 @@ export function createAIMiddleware(bot: Bot<SlushaContext>) {
                 }
             }
 
-            const blockedByProviderMessage = character
-                ? 'API провайдер запрещает тебе отвечать. Возможно это из-за персонажа: '
-                : 'API провайдер запрещает тебе отвечать: ';
+            let blockedByProviderMessage =
+                'API провайдер запрещает тебе отвечать: ';
+            if (character) {
+                blockedByProviderMessage =
+                    'API провайдер запрещает тебе отвечать. Возможно это из-за персонажа: ';
+            }
 
             if (blockReason === 'PROHIBITED_CONTENT') {
                 logger.warn(
@@ -781,10 +701,17 @@ export function createAIMiddleware(bot: Bot<SlushaContext>) {
         }
 
         const name = chatName;
-        const username = ctx.chat?.username ? `(@${ctx.chat.username})` : '';
+        let username = '';
+        if (ctx.chat?.username) {
+            username = `(@${ctx.chat.username})`;
+        }
+        let randomMessageSuffix = '';
+        if (ctx.info.isRandom) {
+            randomMessageSuffix = '(random)';
+        }
 
         logger.info(
-            `Time to get response ${ctx.info.isRandom ? '(random)' : ''}:`,
+            `Time to get response ${randomMessageSuffix}:`,
             (new Date().getTime() - time) / 1000,
             `for "${name}" ${username}. `,
         );


### PR DESCRIPTION
## Summary
- centralize provider and model compatibility as resolved generation capabilities
- select tool-call versus JSON-text structured output in one shared generation helper
- use capabilities for chat history attachments and reuse structured output for character names
- remove the chat structured-actions wrapper and replace conditional ternaries in the handler with if/else branches

## Verification
- `deno check lib/telegram/handlers/ai.ts`
- `deno lint lib/telegram/handlers/ai.ts`
- `deno test --allow-all`